### PR TITLE
fix: Stop persisting derived card arrays to localStorage

### DIFF
--- a/src/lib/cards.ts
+++ b/src/lib/cards.ts
@@ -1,0 +1,38 @@
+import { C1_data, A2_B2_data } from '@/data'
+import { WORD_LEVELS } from '@/enums/enums'
+import { ILanguageCard } from '@/interfaces/interfaces'
+
+type WordLevel = (typeof WORD_LEVELS)[keyof typeof WORD_LEVELS]
+
+export function getDataByLevel(level: WordLevel): ILanguageCard[] {
+    switch (level) {
+        case WORD_LEVELS.C1:
+            return C1_data
+        case WORD_LEVELS.A2B2:
+            return A2_B2_data
+        case WORD_LEVELS.ALL_LEVELS:
+            return [...C1_data, ...A2_B2_data]
+        default:
+            return []
+    }
+}
+
+export function buildAllCards(...sources: ILanguageCard[][]): ILanguageCard[] {
+    return sources.flatMap(source => source.flatMap(card => [card, ...(card.multiple || [])]))
+}
+
+export function shuffleArray(array: ILanguageCard[]): ILanguageCard[] {
+    const shuffled = array.slice()
+    for (let i = shuffled.length - 1; i > 0; i--) {
+        const j = Math.floor(Math.random() * (i + 1))
+        ;[shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]]
+    }
+    return shuffled
+}
+
+export function filterCards(cards: ILanguageCard[], query: string): ILanguageCard[] {
+    const q = query.toLowerCase()
+    return cards.filter(
+        card => card.wordDe.toLowerCase().includes(q) || card.wordRu.toLowerCase().includes(q)
+    )
+}

--- a/src/stores/allCardsStore.ts
+++ b/src/stores/allCardsStore.ts
@@ -3,45 +3,14 @@ import { persist } from 'zustand/middleware'
 import { ICardsStore, ILanguageCard } from '@/interfaces/interfaces'
 import { C1_data, A2_B2_data } from '@/data'
 import { CARDS_CATEGORY, WORD_LEVELS } from '@/enums/enums'
+import { buildAllCards, filterCards, getDataByLevel, shuffleArray } from '@/lib/cards'
 
-// Функция для перемешивания массива
-function shuffleArray(array: ILanguageCard[]) {
-    const shuffled = array.slice()
-    for (let i = shuffled.length - 1; i > 0; i--) {
-        const j = Math.floor(Math.random() * (i + 1))
-        ;[shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]]
-    }
-    return shuffled
-}
-
-export function getDataByLevel(
-    level: (typeof WORD_LEVELS)[keyof typeof WORD_LEVELS]
-): ILanguageCard[] {
-    switch (level) {
-        // case WORD_LEVELS.C1:
-        //     return C1_data
-        case WORD_LEVELS.C1:
-            return C1_data
-        case WORD_LEVELS.A2B2:
-            return A2_B2_data
-        case WORD_LEVELS.ALL_LEVELS:
-            return [...C1_data, ...A2_B2_data]
-        default:
-            return []
-    }
-}
+export { getDataByLevel } from '@/lib/cards'
 
 export const useCardsStore = create<ICardsStore>()(
     persist(
         set => {
-            // Все слова из объединённых данных
-            const allCards = [
-                ...C1_data.flatMap(card => [card, ...(card.multiple || [])]),
-                // ...C1_data.flatMap(card => [card, ...(card.multiple || [])]),
-                ...A2_B2_data.flatMap(card => [card, ...(card.multiple || [])]),
-            ]
-
-            // Перемешанные слова
+            const allCards = buildAllCards(C1_data, A2_B2_data)
             const shuffledAllWords = shuffleArray(allCards)
 
             return {
@@ -61,11 +30,10 @@ export const useCardsStore = create<ICardsStore>()(
 
                 setSelectedWordLevel: (level: (typeof WORD_LEVELS)[keyof typeof WORD_LEVELS]) => {
                     const data = getDataByLevel(level)
-                    const shuffledData = shuffleArray(data)
                     set({
                         selectedWordLevel: level,
                         displayedCards: data,
-                        shuffledCards: shuffledData,
+                        shuffledCards: shuffleArray(data),
                     })
                 },
 
@@ -98,17 +66,10 @@ export const useCardsStore = create<ICardsStore>()(
                     })
                 },
                 updateSearchQuery: (query: string) =>
-                    set(state => {
-                        const filtered = state.allCards.filter(
-                            card =>
-                                card.wordDe.toLowerCase().includes(query.toLowerCase()) ||
-                                card.wordRu.toLowerCase().includes(query.toLowerCase())
-                        )
-                        return {
-                            searchQuery: query,
-                            filteredCards: filtered,
-                        }
-                    }),
+                    set(state => ({
+                        searchQuery: query,
+                        filteredCards: filterCards(state.allCards, query),
+                    })),
                 resetStore: () =>
                     set(state => ({
                         displayedCards: shuffledAllWords,
@@ -118,7 +79,6 @@ export const useCardsStore = create<ICardsStore>()(
                         selectedCardCategory: CARDS_CATEGORY.ALLE,
                         searchQuery: '',
                         filteredCards: shuffledAllWords,
-                        // Preserve favoriteCards
                         favoriteCards: state.favoriteCards,
                     })),
             }
@@ -126,16 +86,35 @@ export const useCardsStore = create<ICardsStore>()(
 
         {
             name: 'unified-cards-storage',
+            version: 1,
             partialize: state => ({
-                itemsPerPage: state.itemsPerPage,
-                displayedCards: state.displayedCards,
+                favoriteCards: state.favoriteCards,
                 selectedWordLevel: state.selectedWordLevel,
                 selectedCardCategory: state.selectedCardCategory,
-                shuffledCards: state.shuffledCards,
-                favoriteCards: state.favoriteCards,
-                searchQuery: state.searchQuery,
-                filteredCards: state.filteredCards,
+                itemsPerPage: state.itemsPerPage,
             }),
+            migrate: persisted => {
+                const p = (persisted ?? {}) as Partial<ICardsStore>
+                return {
+                    favoriteCards: p.favoriteCards ?? [],
+                    selectedWordLevel: p.selectedWordLevel ?? WORD_LEVELS.ALL_LEVELS,
+                    selectedCardCategory: p.selectedCardCategory ?? CARDS_CATEGORY.ALLE,
+                    itemsPerPage: p.itemsPerPage ?? 5,
+                }
+            },
+            merge: (persisted, current) => {
+                if (!persisted) return current
+                const merged = { ...current, ...(persisted as Partial<ICardsStore>) }
+                const levelData = getDataByLevel(merged.selectedWordLevel)
+                return {
+                    ...merged,
+                    displayedCards: levelData,
+                    shuffledCards: shuffleArray(levelData),
+                    filteredCards: merged.allCards,
+                    searchQuery: '',
+                    loading: false,
+                }
+            },
         }
     )
 )


### PR DESCRIPTION
## Summary

The cards store persisted `displayedCards`, `shuffledCards`, and `filteredCards` in addition to settings — duplicating the full ~8500-item dataset several times in localStorage and risking the browser's ~5MB quota (silent persist failure on large data). This change persists only `favoriteCards` and the user settings, and recomputes the derived arrays from the persisted level during rehydration, keeping them consistent with `selectedWordLevel`.

## Changes

- `src/lib/cards.ts` (new) holds the pure card helpers `getDataByLevel`, `buildAllCards`, `shuffleArray`, and `filterCards`, extracted from the store so they are unit-testable without instantiating the store/persist.
- `allCardsStore.ts` imports those helpers (and re-exports `getDataByLevel` so `@/stores` consumers are unaffected). `partialize` now stores only `favoriteCards`, `selectedWordLevel`, `selectedCardCategory`, `itemsPerPage`. Added `version: 1` + `migrate` to trim existing bloated storage to the kept keys, and `merge` to recompute `displayedCards`/`shuffledCards`/`filteredCards` from the persisted level on rehydration (`searchQuery` resets to empty).

## Test Plan

- [x] `npx vitest run --config .claude/vitest.config.ts` — 8 specs covering `getDataByLevel`, `buildAllCards`, `filterCards`
- [x] `npx tsc --noEmit` — no type errors
- [x] `next build` — compiles, all routes generate
- [x] Manual: changed level/category/items-per-page and toggled favorites, reloaded — settings and favorites persist; cards match the selected level; localStorage entry no longer holds card arrays