### PR TITLE
feat: Card provenance fields and zod schema

### DIFF
--- a/src/data/A2-B2-data.ts
+++ b/src/data/A2-B2-data.ts
@@ -4,6 +4,8 @@ import { ILanguageCard } from '@/interfaces/interfaces'
 export const A2_B2_data: ILanguageCard[] = [
     {
         id: `1-${WORD_LEVELS.A2B2}`,
+        sourceBook: 'various',
+        level: WORD_LEVELS.A2B2,
         article: '',
         pluralEnding: '',
         wordDe: 'fahren, fährt, ist gefahren',
@@ -15,6 +17,8 @@ export const A2_B2_data: ILanguageCard[] = [
     },
     {
         id: `2-${WORD_LEVELS.A2B2}`,
+        sourceBook: 'various',
+        level: WORD_LEVELS.A2B2,
         article: '',
         pluralEnding: '',
         wordDe: 'brennen, brennt, hat gebrannt',
@@ -26,6 +30,8 @@ export const A2_B2_data: ILanguageCard[] = [
     },
     {
         id: `3-${WORD_LEVELS.A2B2}`,
+        sourceBook: 'various',
+        level: WORD_LEVELS.A2B2,
         article: '',
         pluralEnding: '',
         wordDe: 'empfangen, empfängt, hat empfangen',
@@ -37,6 +43,8 @@ export const A2_B2_data: ILanguageCard[] = [
     },
     {
         id: `4-${WORD_LEVELS.A2B2}`,
+        sourceBook: 'various',
+        level: WORD_LEVELS.A2B2,
         article: '',
         pluralEnding: '',
         wordDe: 'empfehlen, empfiehlt, hat empfohlen',
@@ -48,6 +56,8 @@ export const A2_B2_data: ILanguageCard[] = [
     },
     {
         id: `5-${WORD_LEVELS.A2B2}`,
+        sourceBook: 'various',
+        level: WORD_LEVELS.A2B2,
         article: '',
         pluralEnding: '',
         wordDe: 'erschrecken, erschrickt, ist erschrocken',
@@ -59,6 +69,8 @@ export const A2_B2_data: ILanguageCard[] = [
     },
     {
         id: `6-${WORD_LEVELS.A2B2}`,
+        sourceBook: 'various',
+        level: WORD_LEVELS.A2B2,
         article: '',
         pluralEnding: '',
         wordDe: 'fangen, fängt, hat gefangen',
@@ -70,6 +82,8 @@ export const A2_B2_data: ILanguageCard[] = [
     },
     {
         id: `7-${WORD_LEVELS.A2B2}`,
+        sourceBook: 'various',
+        level: WORD_LEVELS.A2B2,
         article: '',
         pluralEnding: '',
         wordDe: 'fliehen, flieht, ist geflohen',
@@ -81,6 +95,8 @@ export const A2_B2_data: ILanguageCard[] = [
     },
     {
         id: `8-${WORD_LEVELS.A2B2}`,
+        sourceBook: 'various',
+        level: WORD_LEVELS.A2B2,
         article: '',
         pluralEnding: '',
         wordDe: 'fließen, fließt, ist geflossen',
@@ -92,6 +108,8 @@ export const A2_B2_data: ILanguageCard[] = [
     },
     {
         id: `9-${WORD_LEVELS.A2B2}`,
+        sourceBook: 'various',
+        level: WORD_LEVELS.A2B2,
         article: '',
         pluralEnding: '',
         wordDe: 'fressen, frisst, hat gefressen',
@@ -103,6 +121,8 @@ export const A2_B2_data: ILanguageCard[] = [
     },
     {
         id: `10-${WORD_LEVELS.A2B2}`,
+        sourceBook: 'various',
+        level: WORD_LEVELS.A2B2,
         article: '',
         pluralEnding: '',
         wordDe: 'frieren, friert, hat gefroren',
@@ -114,6 +134,8 @@ export const A2_B2_data: ILanguageCard[] = [
     },
     {
         id: `11-${WORD_LEVELS.A2B2}`,
+        sourceBook: 'various',
+        level: WORD_LEVELS.A2B2,
         article: '',
         pluralEnding: '',
         wordDe: 'beginnen, beginnt, hat begonnen',
@@ -125,6 +147,8 @@ export const A2_B2_data: ILanguageCard[] = [
     },
     {
         id: `12-${WORD_LEVELS.A2B2}`,
+        sourceBook: 'various',
+        level: WORD_LEVELS.A2B2,
         article: '',
         pluralEnding: '',
         wordDe: 'bieten, bietet, hat geboten',
@@ -136,6 +160,8 @@ export const A2_B2_data: ILanguageCard[] = [
     },
     {
         id: `13-${WORD_LEVELS.A2B2}`,
+        sourceBook: 'various',
+        level: WORD_LEVELS.A2B2,
         article: '',
         pluralEnding: '',
         wordDe: 'gelten, gilt, hat gegolten',
@@ -147,6 +173,8 @@ export const A2_B2_data: ILanguageCard[] = [
     },
     {
         id: `14-${WORD_LEVELS.A2B2}`,
+        sourceBook: 'various',
+        level: WORD_LEVELS.A2B2,
         article: '',
         pluralEnding: '',
         wordDe: 'genießen, genießt, hat genossen',
@@ -158,6 +186,8 @@ export const A2_B2_data: ILanguageCard[] = [
     },
     {
         id: `15-${WORD_LEVELS.A2B2}`,
+        sourceBook: 'various',
+        level: WORD_LEVELS.A2B2,
         article: '',
         pluralEnding: '',
         wordDe: 'geschehen, geschieht, ist geschehen',
@@ -169,6 +199,8 @@ export const A2_B2_data: ILanguageCard[] = [
     },
     {
         id: `16-${WORD_LEVELS.A2B2}`,
+        sourceBook: 'various',
+        level: WORD_LEVELS.A2B2,
         article: '',
         pluralEnding: '',
         wordDe: 'gewinnen, gewinnt, hat gewonnen',
@@ -180,6 +212,8 @@ export const A2_B2_data: ILanguageCard[] = [
     },
     {
         id: `17-${WORD_LEVELS.A2B2}`,
+        sourceBook: 'various',
+        level: WORD_LEVELS.A2B2,
         article: '',
         pluralEnding: '',
         wordDe: 'gießen, gießt, hat gegossen',
@@ -191,6 +225,8 @@ export const A2_B2_data: ILanguageCard[] = [
     },
     {
         id: `18-${WORD_LEVELS.A2B2}`,
+        sourceBook: 'various',
+        level: WORD_LEVELS.A2B2,
         article: '',
         pluralEnding: '',
         wordDe: 'greifen, greift, hat gegriffen',
@@ -202,6 +238,8 @@ export const A2_B2_data: ILanguageCard[] = [
     },
     {
         id: `19-${WORD_LEVELS.A2B2}`,
+        sourceBook: 'various',
+        level: WORD_LEVELS.A2B2,
         article: '',
         pluralEnding: '',
         wordDe: 'heben, hebt, hat gehoben',
@@ -213,6 +251,8 @@ export const A2_B2_data: ILanguageCard[] = [
     },
     {
         id: `20-${WORD_LEVELS.A2B2}`,
+        sourceBook: 'various',
+        level: WORD_LEVELS.A2B2,
         article: '',
         pluralEnding: '',
         wordDe: 'klingen, klingt, hat geklungen',
@@ -224,6 +264,8 @@ export const A2_B2_data: ILanguageCard[] = [
     },
     {
         id: `21-${WORD_LEVELS.A2B2}`,
+        sourceBook: 'various',
+        level: WORD_LEVELS.A2B2,
         article: '',
         pluralEnding: '',
         wordDe: 'leiden, leidet, hat gelitten',
@@ -235,6 +277,8 @@ export const A2_B2_data: ILanguageCard[] = [
     },
     {
         id: `22-${WORD_LEVELS.A2B2}`,
+        sourceBook: 'various',
+        level: WORD_LEVELS.A2B2,
         article: '',
         pluralEnding: '',
         wordDe: 'messen, misst, hat gemessen',
@@ -246,6 +290,8 @@ export const A2_B2_data: ILanguageCard[] = [
     },
     {
         id: `23-${WORD_LEVELS.A2B2}`,
+        sourceBook: 'various',
+        level: WORD_LEVELS.A2B2,
         article: '',
         pluralEnding: '',
         wordDe: 'reiten, reitet, ist geritten',
@@ -257,6 +303,8 @@ export const A2_B2_data: ILanguageCard[] = [
     },
     {
         id: `24-${WORD_LEVELS.A2B2}`,
+        sourceBook: 'various',
+        level: WORD_LEVELS.A2B2,
         article: '',
         pluralEnding: '',
         wordDe: 'rennen, rennt, ist gerannt',
@@ -268,6 +316,8 @@ export const A2_B2_data: ILanguageCard[] = [
     },
     {
         id: `25-${WORD_LEVELS.A2B2}`,
+        sourceBook: 'various',
+        level: WORD_LEVELS.A2B2,
         article: '',
         pluralEnding: '',
         wordDe: 'schieben, schiebt, hat geschoben',
@@ -279,6 +329,8 @@ export const A2_B2_data: ILanguageCard[] = [
     },
     {
         id: `26-${WORD_LEVELS.A2B2}`,
+        sourceBook: 'various',
+        level: WORD_LEVELS.A2B2,
         article: '',
         pluralEnding: '',
         wordDe: 'schießen, schießt, hat geschossen',
@@ -290,6 +342,8 @@ export const A2_B2_data: ILanguageCard[] = [
     },
     {
         id: `27-${WORD_LEVELS.A2B2}`,
+        sourceBook: 'various',
+        level: WORD_LEVELS.A2B2,
         article: '',
         pluralEnding: '',
         wordDe: 'schlagen, schlägt, hat geschlagen',
@@ -301,6 +355,8 @@ export const A2_B2_data: ILanguageCard[] = [
     },
     {
         id: `28-${WORD_LEVELS.A2B2}`,
+        sourceBook: 'various',
+        level: WORD_LEVELS.A2B2,
         article: '',
         pluralEnding: '',
         wordDe: 'schreien, schreit, hat geschrien',
@@ -312,6 +368,8 @@ export const A2_B2_data: ILanguageCard[] = [
     },
     {
         id: `29-${WORD_LEVELS.A2B2}`,
+        sourceBook: 'various',
+        level: WORD_LEVELS.A2B2,
         article: '',
         pluralEnding: '',
         wordDe: 'schweigen, schweigt, hat geschwiegen',
@@ -323,6 +381,8 @@ export const A2_B2_data: ILanguageCard[] = [
     },
     {
         id: `30-${WORD_LEVELS.A2B2}`,
+        sourceBook: 'various',
+        level: WORD_LEVELS.A2B2,
         article: '',
         pluralEnding: '',
         wordDe: 'senden, sendet, hat gesandt',
@@ -334,6 +394,8 @@ export const A2_B2_data: ILanguageCard[] = [
     },
     {
         id: `31-${WORD_LEVELS.A2B2}`,
+        sourceBook: 'various',
+        level: WORD_LEVELS.A2B2,
         article: '',
         pluralEnding: '',
         wordDe: 'springen, springt, ist gesprungen',
@@ -345,6 +407,8 @@ export const A2_B2_data: ILanguageCard[] = [
     },
     {
         id: `32-${WORD_LEVELS.A2B2}`,
+        sourceBook: 'various',
+        level: WORD_LEVELS.A2B2,
         article: '',
         pluralEnding: '',
         wordDe: 'stechen, sticht, hat gestochen',
@@ -356,6 +420,8 @@ export const A2_B2_data: ILanguageCard[] = [
     },
     {
         id: `33-${WORD_LEVELS.A2B2}`,
+        sourceBook: 'various',
+        level: WORD_LEVELS.A2B2,
         article: '',
         pluralEnding: '',
         wordDe: 'steigen, steigt, ist gestiegen',
@@ -367,6 +433,8 @@ export const A2_B2_data: ILanguageCard[] = [
     },
     {
         id: `34-${WORD_LEVELS.A2B2}`,
+        sourceBook: 'various',
+        level: WORD_LEVELS.A2B2,
         article: '',
         pluralEnding: '',
         wordDe: 'üblich',
@@ -378,6 +446,8 @@ export const A2_B2_data: ILanguageCard[] = [
     },
     {
         id: `35-${WORD_LEVELS.A2B2}`,
+        sourceBook: 'various',
+        level: WORD_LEVELS.A2B2,
         article: '',
         pluralEnding: '',
         wordDe: 'sterben, stirbt, ist gestorben',
@@ -389,6 +459,8 @@ export const A2_B2_data: ILanguageCard[] = [
     },
     {
         id: `36-${WORD_LEVELS.A2B2}`,
+        sourceBook: 'various',
+        level: WORD_LEVELS.A2B2,
         article: '',
         pluralEnding: '',
         wordDe: 'stinken, stinkt, hat gestunken',
@@ -400,6 +472,8 @@ export const A2_B2_data: ILanguageCard[] = [
     },
     {
         id: `37-${WORD_LEVELS.A2B2}`,
+        sourceBook: 'various',
+        level: WORD_LEVELS.A2B2,
         article: '',
         pluralEnding: '',
         wordDe: 'stoßen, stößt, hat gestoßen',
@@ -411,6 +485,8 @@ export const A2_B2_data: ILanguageCard[] = [
     },
     {
         id: `38-${WORD_LEVELS.A2B2}`,
+        sourceBook: 'various',
+        level: WORD_LEVELS.A2B2,
         article: '',
         pluralEnding: '',
         wordDe: 'treiben, treibt, hat getrieben',
@@ -422,6 +498,8 @@ export const A2_B2_data: ILanguageCard[] = [
     },
     {
         id: `39-${WORD_LEVELS.A2B2}`,
+        sourceBook: 'various',
+        level: WORD_LEVELS.A2B2,
         article: '',
         pluralEnding: '',
         wordDe: 'treten, tritt, ist/hat getreten',
@@ -433,6 +511,8 @@ export const A2_B2_data: ILanguageCard[] = [
     },
     {
         id: `40-${WORD_LEVELS.A2B2}`,
+        sourceBook: 'various',
+        level: WORD_LEVELS.A2B2,
         article: '',
         pluralEnding: '',
         wordDe: 'verschwinden, verschwindet, ist verschwunden',
@@ -444,6 +524,8 @@ export const A2_B2_data: ILanguageCard[] = [
     },
     {
         id: `41-${WORD_LEVELS.A2B2}`,
+        sourceBook: 'various',
+        level: WORD_LEVELS.A2B2,
         article: '',
         pluralEnding: '',
         wordDe: 'verzeihen, verzeiht, hat verziehen',
@@ -455,6 +537,8 @@ export const A2_B2_data: ILanguageCard[] = [
     },
     {
         id: `42-${WORD_LEVELS.A2B2}`,
+        sourceBook: 'various',
+        level: WORD_LEVELS.A2B2,
         article: '',
         pluralEnding: '',
         wordDe: 'wachsen, wächst, ist gewachsen',
@@ -466,6 +550,8 @@ export const A2_B2_data: ILanguageCard[] = [
     },
     {
         id: `43-${WORD_LEVELS.A2B2}`,
+        sourceBook: 'various',
+        level: WORD_LEVELS.A2B2,
         article: '',
         pluralEnding: '',
         wordDe: 'wenden, wendet, hat gewandt',
@@ -477,6 +563,8 @@ export const A2_B2_data: ILanguageCard[] = [
     },
     {
         id: `44-${WORD_LEVELS.A2B2}`,
+        sourceBook: 'various',
+        level: WORD_LEVELS.A2B2,
         article: '',
         pluralEnding: '',
         wordDe: 'werfen, wirft, hat geworfen',
@@ -488,6 +576,8 @@ export const A2_B2_data: ILanguageCard[] = [
     },
     {
         id: `45-${WORD_LEVELS.A2B2}`,
+        sourceBook: 'various',
+        level: WORD_LEVELS.A2B2,
         article: '',
         pluralEnding: '',
         wordDe: 'wiegen, wiegt, hat gewogen',
@@ -499,6 +589,8 @@ export const A2_B2_data: ILanguageCard[] = [
     },
     {
         id: `46-${WORD_LEVELS.A2B2}`,
+        sourceBook: 'various',
+        level: WORD_LEVELS.A2B2,
         article: '',
         pluralEnding: '',
         wordDe: 'ziehen, zieht, hat gezogen',
@@ -510,6 +602,8 @@ export const A2_B2_data: ILanguageCard[] = [
     },
     {
         id: `47-${WORD_LEVELS.A2B2}`,
+        sourceBook: 'various',
+        level: WORD_LEVELS.A2B2,
         article: '',
         pluralEnding: '',
         wordDe: 'zwingen, zwingt, hat gezwungen',
@@ -521,6 +615,8 @@ export const A2_B2_data: ILanguageCard[] = [
     },
     {
         id: `48-${WORD_LEVELS.A2B2}`,
+        sourceBook: 'various',
+        level: WORD_LEVELS.A2B2,
         article: '',
         pluralEnding: '',
         wordDe: 'erneuern, erneuert, hat erneuert',
@@ -532,6 +628,8 @@ export const A2_B2_data: ILanguageCard[] = [
     },
     {
         id: `49-${WORD_LEVELS.A2B2}`,
+        sourceBook: 'various',
+        level: WORD_LEVELS.A2B2,
         article: '',
         pluralEnding: '',
         wordDe: 'eventuell',
@@ -543,6 +641,8 @@ export const A2_B2_data: ILanguageCard[] = [
     },
     {
         id: `50-${WORD_LEVELS.A2B2}`,
+        sourceBook: 'various',
+        level: WORD_LEVELS.A2B2,
         article: '',
         pluralEnding: '',
         wordDe: 'teilnehmen, nimmt teil, hat teilgenommen',
@@ -554,6 +654,8 @@ export const A2_B2_data: ILanguageCard[] = [
     },
     {
         id: `51-${WORD_LEVELS.A2B2}`,
+        sourceBook: 'various',
+        level: WORD_LEVELS.A2B2,
         article: 'die',
         pluralEnding: ', -en',
         wordDe: 'Verwaltung',
@@ -565,6 +667,8 @@ export const A2_B2_data: ILanguageCard[] = [
     },
     {
         id: `52-${WORD_LEVELS.A2B2}`,
+        sourceBook: 'various',
+        level: WORD_LEVELS.A2B2,
         article: '',
         pluralEnding: '',
         wordDe: 'bergen, birgt, hat geborgen',
@@ -576,6 +680,8 @@ export const A2_B2_data: ILanguageCard[] = [
     },
     {
         id: `53-${WORD_LEVELS.A2B2}`,
+        sourceBook: 'various',
+        level: WORD_LEVELS.A2B2,
         article: '',
         pluralEnding: '',
         wordDe: 'binden, bindet, hat gebunden',
@@ -587,6 +693,8 @@ export const A2_B2_data: ILanguageCard[] = [
     },
     {
         id: `54-${WORD_LEVELS.A2B2}`,
+        sourceBook: 'various',
+        level: WORD_LEVELS.A2B2,
         article: '',
         pluralEnding: '',
         wordDe: 'blasen, bläst, hat geblasen',
@@ -598,6 +706,8 @@ export const A2_B2_data: ILanguageCard[] = [
     },
     {
         id: `55-${WORD_LEVELS.A2B2}`,
+        sourceBook: 'various',
+        level: WORD_LEVELS.A2B2,
         article: '',
         pluralEnding: '',
         wordDe: 'dringen, dringt, ist gedrungen',
@@ -609,6 +719,8 @@ export const A2_B2_data: ILanguageCard[] = [
     },
     {
         id: `56-${WORD_LEVELS.A2B2}`,
+        sourceBook: 'various',
+        level: WORD_LEVELS.A2B2,
         article: '',
         pluralEnding: '',
         wordDe: 'empfinden, empfindet, hat empfunden',
@@ -620,6 +732,8 @@ export const A2_B2_data: ILanguageCard[] = [
     },
     {
         id: `57-${WORD_LEVELS.A2B2}`,
+        sourceBook: 'various',
+        level: WORD_LEVELS.A2B2,
         article: '',
         pluralEnding: '',
         wordDe: 'erlöschen, erlischt, ist erloschen',
@@ -631,6 +745,8 @@ export const A2_B2_data: ILanguageCard[] = [
     },
     {
         id: `58-${WORD_LEVELS.A2B2}`,
+        sourceBook: 'various',
+        level: WORD_LEVELS.A2B2,
         article: '',
         pluralEnding: '',
         wordDe: 'erwägen, erwägt, hat erwogen',
@@ -644,6 +760,8 @@ export const A2_B2_data: ILanguageCard[] = [
     },
     {
         id: `59-${WORD_LEVELS.A2B2}`,
+        sourceBook: 'various',
+        level: WORD_LEVELS.A2B2,
         article: '',
         pluralEnding: '',
         wordDe: 'flechten, flicht, hat geflochten',
@@ -655,6 +773,8 @@ export const A2_B2_data: ILanguageCard[] = [
     },
     {
         id: `60-${WORD_LEVELS.A2B2}`,
+        sourceBook: 'various',
+        level: WORD_LEVELS.A2B2,
         article: '',
         pluralEnding: '',
         wordDe: 'gebären, gebiert, hat geboren',

--- a/src/data/C1-data.ts
+++ b/src/data/C1-data.ts
@@ -4,6 +4,8 @@ import { ILanguageCard } from '@/interfaces/interfaces'
 export const C1_data: ILanguageCard[] = [
     {
         id: `153-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -n',
         wordDe: 'Lieferkette',
@@ -15,6 +17,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `137-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'mehrheitlich',
@@ -26,6 +30,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `563-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'die Oberhand haben, hat, hatte, hat gehabt',
@@ -37,6 +43,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `428-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'benachteiligen, benachteiligt, benachteiligte, hat benachteiligt',
@@ -48,6 +56,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `626-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: '',
         wordDe: 'Bezugsdauer',
@@ -59,6 +69,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `89-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -en',
         wordDe: 'Qual',
@@ -70,6 +82,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `442-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'erfolgversprechend',
@@ -81,6 +95,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `176-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -en',
         wordDe: 'Verzögerung',
@@ -92,6 +108,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `228-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -en',
         wordDe: 'Leitendensitzung',
@@ -104,6 +122,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `338-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -n',
         wordDe: 'Inbetriebnahme',
@@ -115,6 +135,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `383-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'bedürfen, bedarf, bedurfte, hat bedurft',
@@ -126,6 +148,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `507-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'etw. im Griff haben, hat, hatte, hat gehabt',
@@ -137,6 +161,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `241-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'einen Fehler beheben, behebt, behob, hat behoben',
@@ -148,6 +174,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `520-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -en',
         wordDe: 'Anfeindung',
@@ -160,6 +188,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `441-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'bundesweit',
@@ -171,6 +201,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `365-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'der',
         pluralEnding: ', -s',
         wordDe: 'Transfer',
@@ -183,6 +215,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `607-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'aufgehen in + D, geht auf, ging auf, ist aufgegangen',
@@ -194,6 +228,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `579-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'der',
         pluralEnding: ', -e',
         wordDe: 'Renteneintritt',
@@ -206,6 +242,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `223-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'unverpackt',
@@ -219,6 +257,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `590-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'das',
         pluralEnding: ', -e',
         wordDe: 'Stärken- und Schwächenprofil',
@@ -232,6 +272,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `20-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'offene Punkte',
@@ -243,6 +285,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `44-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'einem besonderen Schutz unterliegen, unterliegt, unterlag, hat unterlegen',
@@ -256,6 +300,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `182-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'Forderung stellen, stellt, stellte, hat gestellt',
@@ -268,6 +314,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `570-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'irreführend',
@@ -279,6 +327,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `443-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: '',
         wordDe: 'Jury',
@@ -290,6 +340,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `508-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'aus der Rolle fallen, fällt, fiel, is gefallen',
@@ -301,6 +353,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `194-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: '',
         wordDe: 'Nachhaltigkeit',
@@ -314,6 +368,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `480-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'der',
         pluralEnding: '',
         wordDe: 'Anspruch auf + A',
@@ -325,6 +381,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `96-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'sich beschränken auf, beschränkt sich, beschränkte sich, hat sich beschränkt',
@@ -336,6 +394,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `382-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'diskriminieren, diskriminiert, diskriminierte, hat diskriminiert',
@@ -349,6 +409,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `196-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'belasten, belastet, belastete, hat belastet',
@@ -361,6 +423,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `51-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: '',
         wordDe: 'Zugangsdaten',
@@ -372,6 +436,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `392-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'widerrufen, widerruft, widerrief, hat widerrufen',
@@ -383,6 +449,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `11-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'mittelständisch',
@@ -394,6 +462,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `567-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'ausreichend',
@@ -405,6 +475,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `53-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'übersichtlich',
@@ -416,6 +488,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `248-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'vertuschen, vertuscht, vertuschte, hat vertuscht',
@@ -427,6 +501,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `180-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'das',
         pluralEnding: '',
         wordDe: 'Verhalten',
@@ -438,6 +514,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `477-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'sich rentieren, rentiert sich, rentierte sich, hat sich rentiert',
@@ -449,6 +527,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `377-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'belastbar',
@@ -461,6 +541,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `3-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'vertraulich',
@@ -472,6 +554,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `674-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: '(k)ein Muss sein',
@@ -485,6 +569,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `619-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'herbeiführen, führt herbei, führte herbei, hat herbeigeführt',
@@ -496,6 +582,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `87-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'das',
         pluralEnding: ', -e',
         wordDe: 'Personalgespräch',
@@ -509,6 +597,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `479-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'ablehnen, lehnt ab, lehnte ab, hat abgelehnt',
@@ -521,6 +611,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `138-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'der',
         pluralEnding: ', -¨e',
         wordDe: 'Einwand',
@@ -532,6 +624,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `103-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'ausgelastet',
@@ -543,6 +637,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `542-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -en',
         wordDe: 'Abfindungszahlung',
@@ -556,6 +652,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `1-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'eigenständig',
@@ -567,6 +665,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `599-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'aneinander vorbeileben, lebt vorbei, lebte vorbei, ist vorbeigelebt',
@@ -579,6 +679,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `268-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -en',
         wordDe: 'Dringlichkeit',
@@ -590,6 +692,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `444-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'nachweislich',
@@ -601,6 +705,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `419-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'heikel',
@@ -612,6 +718,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `537-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'blendend',
@@ -623,6 +731,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `317-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'zeitversetzt',
@@ -634,6 +744,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `580-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'verschärft',
@@ -645,6 +757,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `201-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -en',
         wordDe: 'Verarbeitung',
@@ -656,6 +770,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `463-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'das',
         pluralEnding: ', -s',
         wordDe: 'Update',
@@ -669,6 +785,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `569-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'erwerbsfähig',
@@ -681,6 +799,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `623-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'erwerbslos',
@@ -692,6 +812,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `670-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: '',
         wordDe: 'Einsatzbereitschaft',
@@ -703,6 +825,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `346-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'der',
         pluralEnding: ', -en',
         wordDe: 'Investor',
@@ -716,6 +840,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `319-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'der',
         pluralEnding: ', -e',
         wordDe: 'Fehlschluss',
@@ -728,6 +854,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `181-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: '',
         wordDe: 'Falschlieferung',
@@ -740,6 +868,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `532-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'schließen lassen auf + A., lässt schließen, ließ schließen, hat schließen lassen',
@@ -751,6 +881,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `274-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'der',
         pluralEnding: ', -e',
         wordDe: 'Rückruf',
@@ -762,6 +894,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `314-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: '',
         wordDe: 'Zugewandtheit',
@@ -773,6 +907,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `37-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'vorgehen, geht vor, ging vor, ist vorgegangen',
@@ -784,6 +920,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `189-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -en',
         wordDe: 'Liefervereinbarung',
@@ -797,6 +935,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `230-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -en',
         wordDe: 'Arbeitszeitenregelung',
@@ -810,6 +950,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `22-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'Überstunden abbauen, baut ab, baute ab, hat abgebaut',
@@ -821,6 +963,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `369-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -en',
         wordDe: 'Einkommenssteuererklärung',
@@ -832,6 +976,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `97-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -en',
         wordDe: 'Rückmeldung',
@@ -843,6 +989,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `257-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'das',
         pluralEnding: ', -en',
         wordDe: 'Enddatum',
@@ -854,6 +1002,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `107-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'auf dem Laufenden sein, ist, war, ist gewesen',
@@ -866,6 +1016,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `605-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'sich absichern, sichert sich ab, sicherte sich ab, hat sich abgesichert',
@@ -877,6 +1029,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `191-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -en',
         wordDe: 'Unregelmäßigkeit',
@@ -890,6 +1044,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `261-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -n',
         wordDe: 'Sofortmaßnahme',
@@ -901,6 +1057,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `114-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'das',
         pluralEnding: ', -e',
         wordDe: 'Finanzierungskonzept',
@@ -913,6 +1071,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `376-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'dynamisch',
@@ -926,6 +1086,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `451-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -en',
         wordDe: 'Anwendung',
@@ -937,6 +1099,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `653-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'übertreffen, übertrifft, übertraf, hat übertroffen',
@@ -948,6 +1112,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `208-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'vermeiden, vermeidet, vermied, hat vermieden',
@@ -959,6 +1125,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `678-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: '',
         wordDe: 'Teilhabe',
@@ -970,6 +1138,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `534-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'angeblich',
@@ -982,6 +1152,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `118-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'unzureichend',
@@ -993,6 +1165,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `406-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'das',
         pluralEnding: ', -e',
         wordDe: 'Instrument',
@@ -1006,6 +1180,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `188-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -en',
         wordDe: 'Regelung',
@@ -1018,6 +1194,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `561-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'katastrophal',
@@ -1029,6 +1207,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `513-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'meckern, meckert, meckerte, hat gemeckert',
@@ -1040,6 +1220,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `203-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: '',
         wordDe: 'Herstellungsbedingungen',
@@ -1053,6 +1235,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `485-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'lahmlegen, legt lahm, legte lahm, hat lahmgelegt',
@@ -1064,6 +1248,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `324-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'sich handeln um, handelt sich, handelte sich, hat sich gehandelt',
@@ -1075,6 +1261,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `675-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'perspektivisch',
@@ -1087,6 +1275,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `393-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'gewähren, gewährt, gewährte, hat gewährt',
@@ -1098,6 +1288,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `397-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'formlos',
@@ -1109,6 +1301,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `450-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'der',
         pluralEnding: ', -e',
         wordDe: 'Zeitraum',
@@ -1120,6 +1314,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `266-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'ausgehen von, geht aus von, ging aus, ist ausgegangen von',
@@ -1131,6 +1327,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `409-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'einer Pflicht nachkommen, kommt nach, kam nach, ist nachgekommen',
@@ -1142,6 +1340,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `129-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'der',
         pluralEnding: ', -e',
         wordDe: 'Sicherheitsstift',
@@ -1154,6 +1354,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `498-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'begreifen, begreift, begriff, hat begriffen',
@@ -1165,6 +1367,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `643-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'das',
         pluralEnding: ', -e',
         wordDe: 'Stereotyp',
@@ -1176,6 +1380,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `551-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: '(un)zumutbar',
@@ -1187,6 +1393,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `334-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: '',
         wordDe: 'Barrierefreiheit',
@@ -1199,6 +1407,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `492-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'über den eigenen Tellerrand blicken, blickt, blickte, hat geblickt',
@@ -1211,6 +1421,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `50-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'ausdrücklich',
@@ -1222,6 +1434,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `593-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -en',
         wordDe: 'Zielsetzung',
@@ -1233,6 +1447,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `639-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -en',
         wordDe: 'Formalität',
@@ -1246,6 +1462,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `12-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'vor Ort',
@@ -1257,6 +1475,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `452-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -s',
         wordDe: 'App',
@@ -1268,6 +1488,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `247-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'verteufeln, verteufelt, verteufelte, hat verteufelt',
@@ -1281,6 +1503,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `47-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'betreffen, betrifft, betraf, hat betroffen',
@@ -1292,6 +1516,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `167-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'beziehen, bezieht, bezog, hat bezogen',
@@ -1303,6 +1529,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `105-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'der',
         pluralEnding: ', -e',
         wordDe: 'Abgabetermin',
@@ -1314,6 +1542,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `284-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'lösungsorientiert',
@@ -1327,6 +1557,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `207-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'wiederverwerten, verwertet wieder, verwertete wieder, hat wiederverwertet',
@@ -1338,6 +1570,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `308-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'proaktiv',
@@ -1349,6 +1583,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `162-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'angespannt',
@@ -1360,6 +1596,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `251-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'abwägen, wägt ab, wog ab, hat abgewogen',
@@ -1372,6 +1610,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `216-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -en',
         wordDe: 'Inventur',
@@ -1383,6 +1623,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `337-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: '',
         wordDe: 'Effizienz',
@@ -1394,6 +1636,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `378-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'rassistisch',
@@ -1407,6 +1651,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `119-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'gewerblich',
@@ -1418,6 +1664,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `339-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'hinauswollen auf, will hinaus, wollte hinaus, hat hinausgewollt',
@@ -1429,6 +1677,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `123-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: '',
         wordDe: 'Funktionsfähigkeit',
@@ -1440,6 +1690,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `71-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -en',
         wordDe: 'Abwesenheit',
@@ -1451,6 +1703,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `487-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'mental',
@@ -1463,6 +1717,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `466-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'appellieren an, appelliert, appellierte, hat appelliert',
@@ -1475,6 +1731,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `484-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'durchaus',
@@ -1486,6 +1744,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `499-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -n',
         wordDe: 'Beilage',
@@ -1497,6 +1757,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `311-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'zu sprechen kommen auf',
@@ -1508,6 +1770,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `572-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'sicherstellen, stellt sicher, stellte sicher, hat sichergestellt',
@@ -1520,6 +1784,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `213-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'hauptsächlich',
@@ -1531,6 +1797,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `657-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'abgesehen von',
@@ -1542,6 +1810,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `78-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -n',
         wordDe: 'Vorgehensweise',
@@ -1553,6 +1823,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `540-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'der',
         pluralEnding: ', "-e',
         wordDe: 'Auflösungsvertrag',
@@ -1566,6 +1838,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `179-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'der',
         pluralEnding: ', -n',
         wordDe: 'Bestandskunde',
@@ -1577,6 +1851,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `149-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'derzeit',
@@ -1588,6 +1864,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `32-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -en',
         wordDe: 'Einarbeitung',
@@ -1599,6 +1877,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `503-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'schweigen, schweigt, schwieg, hat geschwiegen',
@@ -1610,6 +1890,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `101-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -n',
         wordDe: 'Übergabe',
@@ -1621,6 +1903,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `318-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'gelegentlich',
@@ -1632,6 +1916,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `575-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -en',
         wordDe: 'Zuwanderung',
@@ -1643,6 +1929,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `431-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'der',
         pluralEnding: ', -e',
         wordDe: 'Führungsstil',
@@ -1656,6 +1944,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `309-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'zügig',
@@ -1667,6 +1957,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `445-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'das',
         pluralEnding: ', -s',
         wordDe: 'Start-up',
@@ -1679,6 +1971,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `122-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'einsatzbereit',
@@ -1691,6 +1985,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `565-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'branchenübergreifend',
@@ -1703,6 +1999,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `79-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'schildern, schildert, schilderte, hat geschildert',
@@ -1714,6 +2012,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `15-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'Ziele festlegen, legt fest, legte fest, hat festgelegt',
@@ -1725,6 +2025,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `10-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'wettbewerbsfähig',
@@ -1737,6 +2039,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `74-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'abweisen, weist ab, wies ab, hat abgewiesen',
@@ -1748,6 +2052,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `282-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -en',
         wordDe: 'Kernarbeitszeit',
@@ -1761,6 +2067,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `17-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -en',
         wordDe: 'Einschätzung',
@@ -1772,6 +2080,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `461-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'der',
         pluralEnding: ', -s',
         wordDe: 'Support',
@@ -1784,6 +2094,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `548-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'das',
         pluralEnding: ', -se',
         wordDe: 'Beschäftigungsverhältnis',
@@ -1795,6 +2107,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `530-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'zweifellos',
@@ -1806,6 +2120,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `55-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'einsehbar',
@@ -1817,6 +2133,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `65-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'der',
         pluralEnding: '',
         wordDe: 'Betreiber',
@@ -1828,6 +2146,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `322-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'vernachlässigen, vernachlässigt, vernachlässigte, hat vernachlässigt',
@@ -1839,6 +2159,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `476-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -n',
         wordDe: 'Palette',
@@ -1851,6 +2173,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `35-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'überprüfen, überprüft, überprüfte, hat überprüft',
@@ -1862,6 +2186,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `671-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'sich einstellen auf, stellt sich, stellte sich, hat sich eingestellt',
@@ -1874,6 +2200,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `349-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -en',
         wordDe: 'Rechtsform',
@@ -1887,6 +2215,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `612-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'rückwirkend',
@@ -1898,6 +2228,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `375-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -en',
         wordDe: 'Verstärkung',
@@ -1911,6 +2243,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `158-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -n',
         wordDe: 'Ware',
@@ -1922,6 +2256,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `294-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'frei Haus',
@@ -1933,6 +2269,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `315-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'ein',
         pluralEnding: '',
         wordDe: 'gepflegtes Äußeres',
@@ -1944,6 +2282,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `576-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'ausgleichen, gleicht aus, glich aus, hat ausgeglichen',
@@ -1956,6 +2296,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `617-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'beeinflussen, beeinflusst, beeinflusste, hat beeinflusst',
@@ -1968,6 +2310,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `637-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'entkräften, entkräftet, entkräftete, hat entkräftet',
@@ -1979,6 +2323,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `401-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'der',
         pluralEnding: ', -en',
         wordDe: 'Pflegegrad',
@@ -1991,6 +2337,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `646-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -n',
         wordDe: 'Auswahlrunde',
@@ -2004,6 +2352,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `594-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -en',
         wordDe: 'Berufslaufbahn',
@@ -2016,6 +2366,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `310-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'unbestritten',
@@ -2027,6 +2379,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `395-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'unterschreiten, unterschreitet, unterschritt, hat unterschritten',
@@ -2038,6 +2392,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `88-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'unnötig',
@@ -2049,6 +2405,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `202-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'der',
         pluralEnding: ', -e',
         wordDe: 'Kunststoff',
@@ -2062,6 +2420,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `161-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: '',
         wordDe: 'Produktionskosten',
@@ -2074,6 +2434,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `353-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'der',
         pluralEnding: ', -s',
         wordDe: 'Fond',
@@ -2087,6 +2449,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `632-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'tariflich',
@@ -2100,6 +2464,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `526-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'dazwischengehen, geht dazwischen, ging dazwischen, ist dazwischengegangen',
@@ -2112,6 +2478,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `27-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'gleichwertig',
@@ -2123,6 +2491,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `226-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'vorbeugen, beugt vor, beugte vor, hat vorgebeugt',
@@ -2134,6 +2504,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `25-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'in der Zwischenzeit',
@@ -2146,6 +2518,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `229-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'abteilungsübergreifend',
@@ -2159,6 +2533,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `33-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -en',
         wordDe: 'Räumlichkeit',
@@ -2170,6 +2546,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `416-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'preisgeben, gibt preis, gab preis, hat preisgegeben',
@@ -2181,6 +2559,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `505-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'versäumen, versäumt, versäumte, hat versäumt',
@@ -2192,6 +2572,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `528-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'auf dem Zettel haben, hat, hatte, hat gehabt',
@@ -2203,6 +2585,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `647-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'alternativ',
@@ -2215,6 +2599,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `488-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -en',
         wordDe: 'Mitwirkung',
@@ -2226,6 +2612,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `512-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'Dampf ablassen, lässt ab, ließ ab, hat abgelassen',
@@ -2237,6 +2625,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `186-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'handhaben, handhabt, handhabte, hat gehandhabt',
@@ -2249,6 +2639,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `121-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -en',
         wordDe: 'Kennzeichnung',
@@ -2260,6 +2652,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `394-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'verfallen, verfällt, verfiel, ist verfallen',
@@ -2272,6 +2666,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `316-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'aufschlussreich',
@@ -2284,6 +2680,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `591-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'anfertigen, fertigt an, fertigte an, hat angefertigt',
@@ -2295,6 +2693,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `283-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'loyal',
@@ -2307,6 +2707,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `253-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -en',
         wordDe: 'Ausschreibung',
@@ -2318,6 +2720,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `295-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'vertiefen, vertieft, vertiefte, hat vertieft',
@@ -2329,6 +2733,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `566-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'demografisch',
@@ -2340,6 +2746,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `630-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'das',
         pluralEnding: ', -s',
         wordDe: 'Jobticket',
@@ -2353,6 +2761,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `459-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -en',
         wordDe: 'Rubrik',
@@ -2365,6 +2775,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `131-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -n',
         wordDe: 'Prüfplakette',
@@ -2376,6 +2788,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `506-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: '',
         wordDe: 'Stimme erheben, erhebt, erhob, hat erhoben',
@@ -2387,6 +2801,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `233-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'erfassen, erfasst, erfasste, hat erfasst',
@@ -2400,6 +2816,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `469-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'der',
         pluralEnding: ', -s',
         wordDe: 'Burn-out',
@@ -2413,6 +2831,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `352-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'das',
         pluralEnding: '',
         wordDe: 'Startkapital',
@@ -2426,6 +2846,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `245-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -en',
         wordDe: 'Schuldzuweisung',
@@ -2438,6 +2860,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `430-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -n',
         wordDe: 'Führungsetage',
@@ -2450,6 +2874,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `110-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'gegen die Wand fahren, fährt, fuhr, ist gefahren',
@@ -2462,6 +2888,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `573-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'aufrechterhalten, hält aufrecht, hielt aufrecht, hat aufrechterhalten',
@@ -2473,6 +2901,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `336-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: '',
         wordDe: 'Präzision',
@@ -2484,6 +2914,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `321-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'unter Beweis stellen, stellt unter Beweis, hat unter Beweis gestellt',
@@ -2495,6 +2927,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `631-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -n',
         wordDe: 'Schichtzulage',
@@ -2508,6 +2942,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `402-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'großziehen, zieht groß, zog groß, hat großgezogen',
@@ -2519,6 +2955,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `269-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'durchgehend',
@@ -2530,6 +2968,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `8-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'der',
         pluralEnding: ', -e',
         wordDe: 'Nachweis',
@@ -2541,6 +2981,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `536-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'schwänzen, schwänzt, schwänzte, hat geschwänzt',
@@ -2552,6 +2994,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `99-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'einvernehmlich',
@@ -2563,6 +3007,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `224-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -en',
         wordDe: 'Wartung',
@@ -2576,6 +3022,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `368-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'der',
         pluralEnding: ', -s',
         wordDe: 'Cookie',
@@ -2587,6 +3035,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `595-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'planmäßig verlaufen, verläuft planmäßig, verlief planmäßig, ist planmäßig verlaufen',
@@ -2599,6 +3049,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `82-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: '',
         wordDe: 'Absatzzahlen',
@@ -2610,6 +3062,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `197-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -en',
         wordDe: 'Kaufentscheidung',
@@ -2623,6 +3077,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `237-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'zertifizieren, zertifiziert, zertifizierte, hat zertifiziert',
@@ -2636,6 +3092,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `648-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'bevorzugen, bevorzugt, bevorzugte, hat bevorzugt',
@@ -2647,6 +3105,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `555-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'der',
         pluralEnding: '',
         wordDe: 'Marktführer',
@@ -2658,6 +3118,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `400-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'der',
         pluralEnding: ', -n',
         wordDe: 'Bedürftige',
@@ -2670,6 +3132,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `432-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'jdm. etw. gönnen, gönnt, gönnte, hat gegönnt',
@@ -2683,6 +3147,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `279-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'billigen, billigt, billigte, hat gebilligt',
@@ -2694,6 +3160,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `127-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'der',
         pluralEnding: ', -n',
         wordDe: 'Sicherheitsbeauftragte',
@@ -2705,6 +3173,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `291-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'profitieren von + D, profitiert, profitierte, hat profitiert',
@@ -2716,6 +3186,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `243-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'essenziell',
@@ -2727,6 +3199,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `439-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'bestehend',
@@ -2738,6 +3212,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `156-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -n',
         wordDe: 'steigende Nachfrage',
@@ -2751,6 +3227,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `676-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'rentabel',
@@ -2763,6 +3241,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `244-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'jdm. etw. näherbringen, bringt näher, brachte näher, hat nähergebracht',
@@ -2775,6 +3255,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `568-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'offenbar',
@@ -2787,6 +3269,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `276-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'zugreifen, greift zu, griff zu, hat zugegriffen',
@@ -2798,6 +3282,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `232-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -en',
         wordDe: 'Dokumentation',
@@ -2811,6 +3297,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `250-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'der',
         pluralEnding: ', -s',
         wordDe: 'Workflow',
@@ -2824,6 +3312,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `544-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'fristgemäß',
@@ -2836,6 +3326,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `625-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'zuversichtlich',
@@ -2848,6 +3340,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `413-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'unrechtmäßig',
@@ -2859,6 +3353,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `586-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'ursprünglich',
@@ -2870,6 +3366,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `521-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'sich zoffen, zofft sich, zoffte sich, hat sich gezofft',
@@ -2883,6 +3381,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `501-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'trösten, tröstet, tröstete, hat getröstet',
@@ -2894,6 +3394,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `360-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -n',
         wordDe: 'Expertise',
@@ -2906,6 +3408,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `151-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'ressourcenschonend',
@@ -2918,6 +3422,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `289-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'bestrebt sein zu + D',
@@ -2930,6 +3436,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `659-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'weit ausholen',
@@ -2943,6 +3451,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `511-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'destruktiv',
@@ -2954,6 +3464,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `225-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'der',
         pluralEnding: '',
         wordDe: 'Verteiler',
@@ -2967,6 +3479,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `483-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'das',
         pluralEnding: '',
         wordDe: 'Darlehen',
@@ -2979,6 +3493,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `560-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -en',
         wordDe: 'Führungsposition',
@@ -2990,6 +3506,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `340-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'setzen auf, setzt auf, setzte auf, hat aufgesetzt',
@@ -3002,6 +3520,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `457-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'in Bezug auf',
@@ -3013,6 +3533,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `629-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -n',
         wordDe: 'Jahresprämie',
@@ -3025,6 +3547,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `281-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'geteilter Meinung sein, ist, war, ist gewesen',
@@ -3036,6 +3560,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `73-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'verknüpfen mit, verknüpft, verknüpfte, hat verknüpft',
@@ -3047,6 +3573,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `547-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -n',
         wordDe: 'Sperre',
@@ -3058,6 +3586,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `195-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'ein gutes Gewissen haben, hat, hatte, hat gehabt',
@@ -3070,6 +3600,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `278-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -en',
         wordDe: 'Beanstandung',
@@ -3083,6 +3615,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `231-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'das',
         pluralEnding: ', -s',
         wordDe: 'Audit',
@@ -3095,6 +3629,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `94-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -n',
         wordDe: 'Kernaufgabe',
@@ -3107,6 +3643,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `608-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'schleichen, schleicht, schlich, ist geschlichen',
@@ -3118,6 +3656,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `159-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: '',
         wordDe: 'Güter',
@@ -3131,6 +3671,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `543-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: '',
         wordDe: 'Kündigungsabsicht',
@@ -3144,6 +3686,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `475-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'der',
         pluralEnding: '',
         wordDe: 'Nachwuchs',
@@ -3156,6 +3700,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `552-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'im Verzug sein, ist, war, ist gewesen',
@@ -3167,6 +3713,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `578-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'der',
         pluralEnding: '',
         wordDe: 'Nachwuchs',
@@ -3178,6 +3726,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `522-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'sich in die Haare kriegen, kriegt, kriegte, hat gekriegt',
@@ -3190,6 +3740,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `204-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'der',
         pluralEnding: ', -¨e',
         wordDe: 'Mangel',
@@ -3203,6 +3755,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `4-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'umfassend',
@@ -3214,6 +3768,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `610-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -en',
         wordDe: 'Sonderschicht',
@@ -3227,6 +3783,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `370-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'der',
         pluralEnding: ', -e',
         wordDe: 'Zuschlag',
@@ -3238,6 +3796,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `31-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'einarbeiten, arbeitet ein, arbeitete ein, hat eingearbeitet',
@@ -3249,6 +3809,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `117-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'der',
         pluralEnding: ', -ände',
         wordDe: 'Brand',
@@ -3260,6 +3822,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `390-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'einholen, holt ein, holte ein, hat eingeholt',
@@ -3272,6 +3836,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `491-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'den Horizont erweitern, erweitert, erweiterte, hat erweitert',
@@ -3283,6 +3849,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `222-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'abfüllen, füllt ab, füllte ab, hat abgefüllt',
@@ -3294,6 +3862,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `255-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'bisher',
@@ -3305,6 +3875,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `404-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'der',
         pluralEnding: ', -e',
         wordDe: 'Einspruch',
@@ -3316,6 +3888,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `217-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'der',
         pluralEnding: '',
         wordDe: 'Pro-Kopf-Verbrauch',
@@ -3327,6 +3901,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `611-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'triftig',
@@ -3338,6 +3914,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `42-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'der',
         pluralEnding: ', -e',
         wordDe: 'Zweck',
@@ -3349,6 +3927,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `298-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'kontaktieren, kontaktiert, kontaktierte, hat kontaktiert',
@@ -3360,6 +3940,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `527-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'schlichten, schlichtet, schlichtete, hat geschlichtet',
@@ -3371,6 +3953,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `414-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'untersagen, untersagt, untersagte, hat untersagt',
@@ -3382,6 +3966,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `124-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'ordnungsgemäß',
@@ -3393,6 +3979,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `516-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'das',
         pluralEnding: ', -e',
         wordDe: 'Werkstück',
@@ -3404,6 +3992,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `80-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'überflüssig',
@@ -3415,6 +4005,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `238-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'ausbaden, badet aus, badete aus, hat ausgebadet',
@@ -3428,6 +4020,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `417-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'verletzend',
@@ -3439,6 +4033,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `60-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'unterschätzen, unterschätzt, unterschätzte, hat unterschätzt',
@@ -3450,6 +4046,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `546-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'missachten, missachtet, missachtete, hat missachtet',
@@ -3461,6 +4059,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `108-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'vervollständigen, vervollständigt, vervollständigte, hat vervollständigt',
@@ -3472,6 +4072,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `418-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'strikt',
@@ -3483,6 +4085,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `564-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'sich widerspiegeln in, spiegelt sich wider, spiegelte sich wider, hat sich widergespiegelt',
@@ -3495,6 +4099,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `425-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'der',
         pluralEnding: ', -änge',
         wordDe: 'Aushang',
@@ -3506,6 +4112,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `9-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'einschlägig',
@@ -3517,6 +4125,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `347-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'das',
         pluralEnding: ', -s',
         wordDe: 'Investment',
@@ -3530,6 +4140,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `462-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'umrechnen, rechnet um, rechnete um, hat umgerechnet',
@@ -3541,6 +4153,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `422-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'meines Erachtens',
@@ -3554,6 +4168,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `490-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'opfern, opfert, opferte, hat geopfert',
@@ -3566,6 +4182,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `601-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'unbürokratisch',
@@ -3577,6 +4195,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `305-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'das',
         pluralEnding: '',
         wordDe: 'Gegenüber',
@@ -3588,6 +4208,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `663-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -en',
         wordDe: 'Eingliederung',
@@ -3599,6 +4221,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `529-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'aller Wahrscheinlichkeit nach',
@@ -3612,6 +4236,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `328-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'ein',
         pluralEnding: '',
         wordDe: 'herkömmliches Verfahren',
@@ -3623,6 +4249,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `323-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'rekonstruieren, rekonstruiert, rekonstruierte, hat rekonstruiert',
@@ -3634,6 +4262,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `198-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -n',
         wordDe: 'Lebensdauer',
@@ -3645,6 +4275,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `482-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'betonen, betont, betonte, hat betont',
@@ -3656,6 +4288,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `583-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'sich fügen, fügt sich, fügte sich, hat sich gefügt',
@@ -3669,6 +4303,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `523-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'im Clinch liegen, liegt, lag, hat gelegen',
@@ -3681,6 +4317,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `502-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: '',
         wordDe: 'Nerven verlieren, verliert, verlor, hat verloren',
@@ -3692,6 +4330,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `144-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'in Präsenz',
@@ -3703,6 +4343,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `344-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -n',
         wordDe: 'Geschäftsidee',
@@ -3716,6 +4358,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `454-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'einbinden, bindet ein, band ein, hat eingebunden',
@@ -3727,6 +4371,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `28-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'freihalten, hält frei, hielt frei, hat freigehalten',
@@ -3738,6 +4384,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `262-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'unverbindlich',
@@ -3749,6 +4397,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `265-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'das',
         pluralEnding: ', -',
         wordDe: 'Anliegen',
@@ -3760,6 +4410,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `146-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'ein Fazit ziehen, zieht, zog, hat gezogen',
@@ -3771,7 +4423,9 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `154-${WORD_LEVELS.C1}`,
-        article: 'die',
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
+        article: 'der',
         pluralEnding: ', -e',
         wordDe: 'Lieferengpass',
         wordRu: 'перебои с поставками; логистический затор',
@@ -3783,6 +4437,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `458-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -en',
         wordDe: 'Maßeinheit',
@@ -3794,6 +4450,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `650-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'hin- und hermailen, mailt hin und her, mailte hin und her, hat hin und her gemailt',
@@ -3807,6 +4465,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `333-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -en',
         wordDe: 'Implementierung',
@@ -3818,6 +4478,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `651-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'keine Umstände machen',
@@ -3830,6 +4492,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `95-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'höhenverstellbar',
@@ -3841,6 +4505,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `531-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'gewiss',
@@ -3852,6 +4518,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `456-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'der',
         pluralEnding: ', -e',
         wordDe: 'Impuls',
@@ -3863,6 +4531,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `427-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'undenkbar',
@@ -3874,6 +4544,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `299-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'akquirieren, akquiriert, akquirierte, hat akquiriert',
@@ -3886,6 +4558,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `112-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'überfordert',
@@ -3899,6 +4573,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `46-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -en',
         wordDe: 'Einwilligung',
@@ -3911,6 +4587,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `602-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'einen Auftrag ergattern, ergattert, ergatterte, hat ergattert',
@@ -3922,6 +4600,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `271-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'kühlen, kühlt, kühlte, hat gekühlt',
@@ -3933,6 +4613,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `412-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'der',
         pluralEnding: ', -e',
         wordDe: 'Verstoß',
@@ -3944,6 +4626,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `519-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -en',
         wordDe: 'Unstimmigkeit',
@@ -3955,6 +4639,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `140-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -n',
         wordDe: 'Rednerliste',
@@ -3966,6 +4652,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `62-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'gefährdet sein, ist, war, ist gewesen',
@@ -3978,6 +4666,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `24-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'der',
         pluralEnding: ', -e',
         wordDe: 'Zuschuss',
@@ -3989,6 +4679,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `190-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: '',
         wordDe: 'Sortimentsumstellung',
@@ -4002,6 +4694,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `644-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'unbeständig',
@@ -4013,6 +4707,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `177-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'der',
         pluralEnding: '',
         wordDe: 'Zulieferer',
@@ -4024,6 +4720,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `163-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'angewiesen sein auf, ist, war, ist gewesen',
@@ -4035,6 +4733,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `83-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'sich in Grenzen halten, hält, hielt, hat gehalten',
@@ -4046,6 +4746,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `638-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'der',
         pluralEnding: '',
         wordDe: 'rote Faden',
@@ -4057,6 +4759,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `325-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'sich hervorragend eignen zu',
@@ -4068,6 +4772,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `665-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -n',
         wordDe: 'Rechtsgrundlage',
@@ -4080,6 +4786,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `634-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'der',
         pluralEnding: ', -ü-e',
         wordDe: 'Bruch',
@@ -4091,6 +4799,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `145-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'plädieren für, plädiert, plädierte, hat plädiert',
@@ -4102,6 +4812,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `517-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'einen',
         pluralEnding: '',
         wordDe: 'guten Moment abpassen, passt ab, passte ab, hat abgepasst',
@@ -4113,6 +4825,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `312-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -en',
         wordDe: 'Sachkompetenz',
@@ -4124,6 +4838,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `165-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'betroffen von',
@@ -4136,6 +4852,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `658-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'anders ausgedrückt',
@@ -4148,6 +4866,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `587-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'festhalten an + D, hält fest, hielt fest, hat festgehalten',
@@ -4159,6 +4879,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `633-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'ankommen gegen, kommt an gegen, kam an gegen, ist angekommen gegen',
@@ -4170,6 +4892,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `285-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'der',
         pluralEnding: ', -äden',
         wordDe: 'Leitfaden',
@@ -4183,6 +4907,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `221-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'das',
         pluralEnding: ', -e',
         wordDe: 'Gefäß',
@@ -4195,6 +4921,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `252-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'ausgeschlossen',
@@ -4207,6 +4935,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `263-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'vertrösten auf, vertröstet, vertröstete, hat vertröstet',
@@ -4219,6 +4949,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `455-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'hinterlegen, hinterlegt, legte hinter, hat hinterlegt',
@@ -4230,6 +4962,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `135-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'sich vergewissern, vergewissert sich, vergewisserte sich, hat sich vergewissert',
@@ -4241,6 +4975,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `628-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'brennen für, brennt, brannte, hat gebrannt',
@@ -4253,6 +4989,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `136-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'einstimmig',
@@ -4264,6 +5002,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `215-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'selbsterklärend',
@@ -4276,6 +5016,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `373-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -en',
         wordDe: 'Identität',
@@ -4287,6 +5029,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `40-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'der',
         pluralEnding: ', -e',
         wordDe: 'Mehrwert',
@@ -4298,6 +5042,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `246-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'unvermeidbar',
@@ -4309,6 +5055,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `545-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'fristlos',
@@ -4320,11 +5068,13 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `2-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -en',
         wordDe: 'Förderung',
         wordRu: 'поддержка, содействие',
-        wordClass: WORD_CLASSES.NEUTRAL,
+        wordClass: WORD_CLASSES.FEMININ,
         exampleDe:
             'Die Förderung von nahestehenden Personen während Trauer ist von großer Bedeutung.',
         exampleRu: 'Поддержка близких во время горя или траура имеет большое значение.',
@@ -4332,6 +5082,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `126-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'instandsetzen, setzt instand, setzte instand, hat instand gesetzt',
@@ -4343,6 +5095,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `254-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'der/die',
         pluralEnding: ', -n',
         wordDe: 'Beteiligte',
@@ -4354,6 +5108,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `387-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'verlangen nach, verlangt, verlangte ,hat verlangt',
@@ -4365,6 +5121,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `664-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'oberflächlich',
@@ -4377,6 +5135,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `533-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'hindeuten auf, deutet hin, deutete hin, hat hingedeutet',
@@ -4388,6 +5148,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `489-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -en',
         wordDe: 'Modalität',
@@ -4399,6 +5161,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `391-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'zulässig',
@@ -4410,6 +5174,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `615-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'verringern, verringert, verringerte, hat verringert',
@@ -4422,6 +5188,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `104-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'zeitaufwendig',
@@ -4433,6 +5201,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `652-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'hinterlassen, hinterlässt, hinterließ, hat hinterlassen',
@@ -4444,6 +5214,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `192-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'abschrecken, schreckt ab, schreckte ab, hat abgeschreckt',
@@ -4455,6 +5227,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `160-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -en',
         wordDe: 'Stückzahl',
@@ -4466,6 +5240,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `465-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'anstoßen, stößt an, stieß an, hat angestoßen',
@@ -4478,6 +5254,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `277-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'aufgebracht',
@@ -4490,6 +5268,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `362-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'tabu',
@@ -4503,6 +5283,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `166-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'sich auswirken auf, wirkt sich aus, wirkte sich aus, hat sich ausgewirkt',
@@ -4514,6 +5296,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `77-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'wert sein, ist, war, ist gewesen',
@@ -4525,6 +5309,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `320-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'bedenkenlos',
@@ -4536,6 +5322,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `302-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'darstellen, stellt dar, stellte dar, hat dargestellt',
@@ -4547,6 +5335,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `93-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'sich vergegenwärtigen, vergegenwärtigt sich, vergegenwärtigte sich, hat sich vergegenwärtigt',
@@ -4559,6 +5349,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `301-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -en',
         wordDe: 'Kundenbindung',
@@ -4572,6 +5364,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `63-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'umdenken, denkt um, dachte	um, hat umgedacht',
@@ -4584,6 +5378,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `134-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'sich absprechen mit, spricht sich ab, sprach sich ab, hat sich abgesprochen',
@@ -4595,6 +5391,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `21-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -en',
         wordDe: 'Verpflegung',
@@ -4607,6 +5405,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `306-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'zur Hand haben',
@@ -4618,6 +5418,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `467-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'aufrüsten, rüstet auf, rüstete auf, hat aufgerüstet',
@@ -4631,6 +5433,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `43-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'personenbezogene Daten',
@@ -4644,6 +5448,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `642-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'rechtfertigen, rechtfertigt, rechtfertigte, hat rechtfertigt',
@@ -4657,6 +5463,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `618-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'selbst verschuldet',
@@ -4670,6 +5478,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `341-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'robust',
@@ -4682,6 +5492,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `415-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'vorfallen, fällt vor, fiel vor, ist vorgefallen',
@@ -4693,6 +5505,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `307-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'ratsam',
@@ -4704,6 +5518,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `636-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'brüchig',
@@ -4715,6 +5531,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `613-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'verfallen, verfällt, verfiel, ist verfallen',
@@ -4727,6 +5545,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `45-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'Daten erheben, erhebt, erhob, hat erhoben',
@@ -4738,6 +5558,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `76-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'der',
         pluralEnding: ', -änge',
         wordDe: 'Vorgang',
@@ -4749,6 +5571,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `199-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: '',
         wordDe: 'Langlebigkeit',
@@ -4760,6 +5584,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `558-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'der',
         pluralEnding: '',
         wordDe: 'Fachkräftemangel',
@@ -4772,6 +5598,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `464-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'der',
         pluralEnding: '',
         wordDe: 'User',
@@ -4785,6 +5613,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `239-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'ausbügeln, bügelt aus, bügelte aus, hat ausgebügelt',
@@ -4796,6 +5626,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `606-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'Steuern abführen, führt ab, führte ab, hat abgeführt',
@@ -4807,6 +5639,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `357-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'ausmachen, macht aus, machte aus, hat ausgemacht',
@@ -4818,6 +5652,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `49-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'ergreifen, ergreift, ergriff, hat ergriffen',
@@ -4829,6 +5665,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `472-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'im Hinblick auf + A',
@@ -4840,6 +5678,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `423-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'erteilen, erteilt, erteilte, hat erteilt',
@@ -4851,6 +5691,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `41-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'der',
         pluralEnding: ', -e',
         wordDe: 'Ablauf',
@@ -4862,6 +5704,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `424-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'sich einverstanden erklären, erklärt sich, erklärte sich, hat sich erklärt',
@@ -4873,6 +5717,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `667-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'zuweisen + D, weist zu, wies zu, hat zugewiesen',
@@ -4886,6 +5732,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `581-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'der',
         pluralEnding: '',
         wordDe: 'raue Umgangston',
@@ -4897,6 +5745,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `635-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -n',
         wordDe: 'Bruchstelle',
@@ -4908,6 +5758,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `436-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'verspannt',
@@ -4919,6 +5771,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `399-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'gutschreiben, schreibt gut, schrieb gut, hat gutgeschrieben',
@@ -4930,6 +5784,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `109-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'loslegen mit, legt los, legte los, hat losgelegt',
@@ -4941,6 +5797,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `5-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -n',
         wordDe: 'Meisterschule',
@@ -4953,6 +5811,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `447-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'verzinsen, verzinst, verzinste, hat verzinst',
@@ -4964,6 +5824,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `240-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'einen Fehler begehen, begeht, beging, hat begangen',
@@ -4976,6 +5838,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `236-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'das',
         pluralEnding: ', -s',
         wordDe: 'Wiki',
@@ -4989,6 +5853,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `645-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'verdrängen, verdrängte, verdrängt, hat verdrängt',
@@ -5001,6 +5867,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `70-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'nötigenfalls',
@@ -5012,6 +5880,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `18-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'der',
         pluralEnding: '',
         wordDe: 'Zusammenhalt',
@@ -5023,6 +5893,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `598-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'Zeit finden für + A, findet, fand, hat gefunden',
@@ -5034,6 +5906,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `128-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -en',
         wordDe: 'Missachtung',
@@ -5045,6 +5919,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `584-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: '',
         wordDe: 'Lohnkosten',
@@ -5058,6 +5934,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `478-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'jmd. etw. schuldig sein, ist, war, ist gewesen',
@@ -5069,6 +5947,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `113-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'der',
         pluralEnding: ', -e',
         wordDe: 'Meilenstein',
@@ -5081,6 +5961,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `600-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'eine Schicht einlegen, legt ein, legte ein, hat eingelegt',
@@ -5092,6 +5974,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `622-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'frühestens',
@@ -5103,6 +5987,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `115-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'der',
         pluralEnding: '',
         wordDe: 'Brandschutz',
@@ -5114,6 +6000,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `350-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'spezifizieren, spezifiziert, spezifizierte, hat spezifiziert',
@@ -5125,6 +6013,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `481-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'aufklären über + A, klärt auf, klärte auf, hat aufgeklärt',
@@ -5136,6 +6026,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `193-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'gewissenhaft',
@@ -5147,6 +6039,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `403-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'der',
         pluralEnding: ', -e',
         wordDe: 'Bescheid',
@@ -5158,6 +6052,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `174-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'sich umsehen nach, sieht sich um, sah sich um, hat sich umgesehen',
@@ -5169,6 +6065,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `7-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'durchstarten, startet durch, startete durch, hat durchgestartet',
@@ -5180,6 +6078,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `91-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'vielbeschäftigt',
@@ -5191,6 +6091,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `494-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -en',
         wordDe: 'Konsequenz',
@@ -5202,6 +6104,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `259-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'freischalten für, schaltet frei, schaltete frei, hat freigeschaltet',
@@ -5213,6 +6117,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `330-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'basieren auf, basiert, basierte, hat basiert',
@@ -5224,6 +6130,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `297-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'beiliegend',
@@ -5235,6 +6143,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `405-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'sich etablieren als + N',
@@ -5246,6 +6156,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `133-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'Ein Gerät warten, wartet, wartete, hat gewartet',
@@ -5258,6 +6170,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `553-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'der',
         pluralEnding: ', "-e',
         wordDe: 'Zahlungsaufschub',
@@ -5269,6 +6183,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `381-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'darlegen, legt dar, legte dar, hat dargelegt',
@@ -5280,6 +6196,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `589-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -n',
         wordDe: 'Bestandsaufnahme',
@@ -5292,6 +6210,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `474-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'leiden unter + D, leidet, litt, hat gelitten',
@@ -5303,6 +6223,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `504-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'verschlimmern, verschlimmert, verschlimmerte, hat verschlimmert',
@@ -5314,6 +6236,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `614-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -en',
         wordDe: 'Sperrzeit',
@@ -5325,6 +6249,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `139-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -en',
         wordDe: 'Wortmeldung',
@@ -5336,6 +6262,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `681-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'unumgänglich',
@@ -5348,6 +6276,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `554-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -en',
         wordDe: 'Belästigung',
@@ -5359,6 +6289,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `120-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'bekämpfen, bekämpft, bekämpfte, hat bekämpft',
@@ -5370,6 +6302,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `75-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'übermitteln, übermittelt, übermittelte, hat übermittelt',
@@ -5381,6 +6315,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `30-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'der',
         pluralEnding: '',
         wordDe: 'Puffer',
@@ -5392,6 +6328,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `562-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'das',
         pluralEnding: ', -se',
         wordDe: 'Kräfteverhältnis',
@@ -5403,6 +6341,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `39-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'aufladen, lädt auf, lud auf, hat aufgeladen',
@@ -5414,6 +6354,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `175-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'verbleiben, verbleibt, verblieb, ist verblieben',
@@ -5425,6 +6367,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `164-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'benötigen, benötigt, benötigte, hat benötigt',
@@ -5436,6 +6380,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `143-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: '',
         wordDe: 'Netiquette',
@@ -5447,6 +6393,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `371-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'ethnisch',
@@ -5460,6 +6408,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `649-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'terminlich eingeschränkt sein, ist, war, ist gewesen',
@@ -5473,6 +6423,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `235-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'gegenchecken, checkt gegen, checkte gegen, hat gegengecheckt',
@@ -5486,6 +6438,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `388-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'vertraulich',
@@ -5497,6 +6451,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `26-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -en',
         wordDe: 'Ausfertigung',
@@ -5508,6 +6464,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `356-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'der',
         pluralEnding: ', -es',
         wordDe: 'Pitch',
@@ -5521,6 +6479,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `14-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'einen Zweck verfolgen, verfolgt, verfolgte, hat verfolgt',
@@ -5532,6 +6492,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `433-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'sorgfältig',
@@ -5543,6 +6505,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `86-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'nervig',
@@ -5554,6 +6518,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `515-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'das',
         pluralEnding: '',
         wordDe: 'Fingerspitzengefühl',
@@ -5566,6 +6532,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `249-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -en',
         wordDe: 'Wertschätzung',
@@ -5579,6 +6547,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `275-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'versiegeln, versiegelt, versiegelte, hat versiegelt',
@@ -5590,6 +6560,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `187-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'längerfristig',
@@ -5601,6 +6573,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `267-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'ausgerechnet',
@@ -5612,6 +6586,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `627-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: '',
         wordDe: 'Altersvorsorge',
@@ -5623,6 +6599,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `296-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'rechnen mit, rechnet, rechnete, hat gerechnet',
@@ -5634,6 +6612,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `668-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'abzielen auf, zielt ab, zielte ab, hat abgezielt',
@@ -5645,6 +6625,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `539-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'betriebsbedingt',
@@ -5658,6 +6640,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `655-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'verhindern, verhindert, verhinderte, hat verhindert',
@@ -5669,6 +6653,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `342-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'strapazierfähig',
@@ -5682,6 +6668,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `435-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'taufrisch',
@@ -5693,6 +6681,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `354-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: '',
         wordDe: 'Eigenmittel',
@@ -5705,6 +6695,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `379-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'inklusiv',
@@ -5718,6 +6710,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `510-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: '',
         wordDe: 'Schuld auf andere schieben, schiebt, schob, hat geschoben',
@@ -5731,6 +6725,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `214-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'der',
         pluralEnding: ', -e',
         wordDe: 'Bestellvorgang',
@@ -5742,6 +6738,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `666-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'der',
         pluralEnding: '',
         wordDe: 'Träger',
@@ -5753,6 +6751,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `355-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'das',
         pluralEnding: ', -e',
         wordDe: 'Potenzial',
@@ -5766,6 +6766,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `206-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -n',
         wordDe: 'Produktionsstätte',
@@ -5779,6 +6781,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `173-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'der',
         pluralEnding: ', -e',
         wordDe: 'Prozess',
@@ -5790,6 +6794,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `669-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'der',
         pluralEnding: ', -e',
         wordDe: 'Aufstieg',
@@ -5802,6 +6808,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `597-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'fertigstellen, stellt fertig, stellte fertig, hat fertiggestellt',
@@ -5813,6 +6821,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `280-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -en',
         wordDe: 'Erwartungshaltung',
@@ -5826,6 +6836,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `525-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'sich einmischen, mischt sich ein, mischte sich ein, hat sich eingemischt',
@@ -5838,6 +6850,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `200-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'hochwertig',
@@ -5849,6 +6863,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `449-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'vor dem Ruin stehen, steht, stand, hat gestanden',
@@ -5860,6 +6876,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `620-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'gelten als + N, gilt als, galt als, hat gegolten als',
@@ -5871,6 +6889,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `673-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'meistern, meistert, meisterte, hat gemeistert',
@@ -5884,6 +6904,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `367-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'der',
         pluralEnding: ', -en',
         wordDe: 'Paragraf',
@@ -5895,6 +6917,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `468-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'der',
         pluralEnding: ', -e',
         wordDe: 'Auszug aus + D',
@@ -5906,6 +6930,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `493-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'das',
         pluralEnding: '',
         wordDe: 'Wohlbefinden',
@@ -5918,6 +6944,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `374-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -en',
         wordDe: 'Diskriminierung',
@@ -5931,6 +6959,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `92-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'mittelfristig',
@@ -5942,6 +6972,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `169-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'der',
         pluralEnding: ', -e',
         wordDe: 'Engpass',
@@ -5953,6 +6985,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `535-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'der',
         pluralEnding: ', -e',
         wordDe: 'Schadstoff',
@@ -5966,6 +7000,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `183-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -en',
         wordDe: 'Auswirkung auf',
@@ -5978,6 +7014,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `293-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'relaxen, relaxt, relaxte, hat relaxt',
@@ -5990,6 +7028,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `358-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'auf den Punkt bringen, bringt, brachte, hat gebracht',
@@ -6001,6 +7041,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `332-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'gendergerecht',
@@ -6012,6 +7054,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `384-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: '',
         wordDe: 'Verschwiegenheit',
@@ -6023,6 +7067,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `48-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -n',
         wordDe: 'Maßnahme',
@@ -6035,6 +7081,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `102-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'die Ärmel hochkrempeln, krempelt hoch, krempelte hoch, hat hochgekrempelt',
@@ -6047,6 +7095,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `98-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'bescheiden',
@@ -6058,6 +7108,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `58-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'der',
         pluralEnding: ', -n',
         wordDe: 'Unberechtigte',
@@ -6069,6 +7121,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `680-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'das',
         pluralEnding: ', -er',
         wordDe: 'Umfeld',
@@ -6081,6 +7135,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `592-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'geradlinig',
@@ -6092,6 +7148,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `287-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'das',
         pluralEnding: '',
         wordDe: 'Wachstum',
@@ -6103,6 +7161,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `571-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -en',
         wordDe: 'Mehrbelastung',
@@ -6114,6 +7174,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `524-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'jdm. Steine in den Weg legen, legt, legte, hat gelegt',
@@ -6126,6 +7188,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `111-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: '',
         wordDe: 'Kapazitäten',
@@ -6138,6 +7202,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `574-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'einbüßen, büßt ein, büßte ein, hat eingebüßt',
@@ -6149,6 +7215,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `234-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'das',
         pluralEnding: ', -s',
         wordDe: 'Feedback',
@@ -6160,6 +7228,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `585-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: '',
         wordDe: 'Steuereinnahmen',
@@ -6171,6 +7241,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `300-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'agieren, agiert, agierte, hat agiert',
@@ -6182,6 +7254,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `116-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'der',
         pluralEnding: '',
         wordDe: 'Feuerlöscher',
@@ -6193,6 +7267,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `366-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'ausschließlich',
@@ -6204,6 +7280,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `59-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'übergehen, geht über, ging	über, ist übergegangen',
@@ -6216,6 +7294,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `410-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -en',
         wordDe: 'Verordnung',
@@ -6227,6 +7307,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `448-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'das',
         pluralEnding: '',
         wordDe: 'Vorhaben',
@@ -6238,6 +7320,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `677-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: '',
         wordDe: 'Sorgfalt',
@@ -6249,6 +7333,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `407-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'Folge leisten',
@@ -6260,6 +7346,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `438-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'das',
         pluralEnding: ', -se',
         wordDe: 'Bedürfnis',
@@ -6271,6 +7359,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `185-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'führen zu, führt zu, führte zu, hat zu geführt',
@@ -6282,6 +7372,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `389-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'zugänglich machen für',
@@ -6294,6 +7386,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `641-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'nachteilig',
@@ -6305,6 +7399,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `616-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'hochladen, lädt hoch, lud hoch, hat hochgeladen',
@@ -6316,6 +7412,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `453-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'auftauchen, taucht auf, tauchte auf, ist aufgetaucht',
@@ -6327,6 +7425,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `329-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'erprobt',
@@ -6338,6 +7438,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `471-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'gespannt auf + A',
@@ -6349,6 +7451,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `157-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -en',
         wordDe: 'Konjunktur',
@@ -6361,6 +7465,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `141-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'das Wort übergeben an, übergibt, übergab, hat übergeben',
@@ -6372,6 +7478,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `363-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'naheliegen, liegt nahe, lag nahe, hat nahegelegen',
@@ -6385,6 +7493,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `69-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -en',
         wordDe: 'Belegschaft',
@@ -6396,6 +7506,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `434-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -en',
         wordDe: 'Stiftung',
@@ -6407,6 +7519,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `331-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'sich richten an, richtet sich, richtete sich, hat sich gerichtet',
@@ -6418,6 +7532,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `470-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -en',
         wordDe: 'Expansion',
@@ -6429,6 +7545,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `582-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -en',
         wordDe: 'Umkehrung',
@@ -6440,6 +7558,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `29-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'dienstlich',
@@ -6451,6 +7571,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `557-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'das',
         pluralEnding: ', -er',
         wordDe: 'Durchschnittsgehalt',
@@ -6462,6 +7584,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `142-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -en',
         wordDe: 'Sicherheitseinweisung',
@@ -6475,6 +7599,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `288-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: '',
         wordDe: 'Verfügbarkeit',
@@ -6486,6 +7612,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `541-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -en',
         wordDe: 'Freistellung',
@@ -6499,6 +7627,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `549-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'der',
         pluralEnding: '',
         wordDe: 'Kündigungsschutz',
@@ -6511,6 +7641,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `440-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: '',
         wordDe: 'Bonität',
@@ -6522,6 +7654,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `538-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'das',
         pluralEnding: ', -se',
         wordDe: 'Zwischenzeugnis',
@@ -6535,6 +7669,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `125-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -en',
         wordDe: 'Instandhaltung',
@@ -6546,6 +7682,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `559-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'abhängen von, hängt ab von, hing ab von, hat abgehangen von',
@@ -6557,6 +7695,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `270-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -en',
         wordDe: 'Geschwindigkeit',
@@ -6568,6 +7708,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `211-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -en',
         wordDe: 'Erwartung',
@@ -6579,6 +7721,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `486-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'der',
         pluralEnding: '',
         wordDe: 'Lebensunterhalt',
@@ -6590,6 +7734,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `509-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'der',
         pluralEnding: '',
         wordDe: 'Frustabbau',
@@ -6601,6 +7747,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `588-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'sich vornehmen, nimmt sich vor, nahm sich vor, hat sich vorgenommen',
@@ -6612,6 +7760,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `38-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'effizient',
@@ -6625,6 +7775,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `437-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'akkreditieren, akkreditiert, akkreditierte, hat akkreditiert',
@@ -6638,6 +7790,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `603-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'sogenannt',
@@ -6649,6 +7803,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `148-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'ausreden lassen, lässt, ließ, hat lassen',
@@ -6661,6 +7817,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `359-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'der',
         pluralEnding: ', -n',
         wordDe: 'Laie',
@@ -6672,6 +7830,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `36-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'konsequent',
@@ -6683,6 +7843,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `609-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -en',
         wordDe: 'Auszeit',
@@ -6694,6 +7856,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `386-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'berechtigt zu',
@@ -6705,6 +7869,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `66-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'betriebsintern',
@@ -6718,6 +7884,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `171-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'die Production hochfahren, fährt hoch, fuhr hoch, hat hochgefahren',
@@ -6730,6 +7898,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `335-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'konfigurieren, konfiguriert, konfigurierte, hat konfiguriert',
@@ -6741,6 +7911,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `672-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -en',
         wordDe: 'Initiativbewerbung',
@@ -6754,6 +7926,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `385-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'vorlegen, legt vor, legte vor, hat vorgelegt',
@@ -6765,6 +7939,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `621-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'der',
         pluralEnding: ', -e',
         wordDe: 'Stichtag',
@@ -6776,6 +7952,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `682-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'zwingend',
@@ -6787,6 +7965,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `218-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: '',
         wordDe: 'Lebensmittelverschwendung',
@@ -6800,6 +7980,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `550-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: '(un)zulässig',
@@ -6811,6 +7993,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `150-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'nachhaltig',
@@ -6824,6 +8008,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `155-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -n',
         wordDe: 'Marktlücke',
@@ -6836,6 +8022,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `13-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'beiderseitig',
@@ -6847,6 +8035,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `286-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -en',
         wordDe: 'Rahmenbedingung',
@@ -6858,6 +8048,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `326-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'dienen zu, dient, diente, hat gedient',
@@ -6869,6 +8061,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `67-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'erfolgen, erfolgt, erfolgte, ist erfolgt',
@@ -6880,6 +8074,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `497-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'durchdrehen, dreht durch, drehte durch, ist durchgedreht',
@@ -6891,6 +8087,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `380-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'zu seinem Recht kommen, kommt, kam, ist gekommen',
@@ -6903,6 +8101,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `84-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'Arbeitszeit aufstocken, stockt auf, stockte auf, hat aufgestockt',
@@ -6916,6 +8116,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `596-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'vorankommen, kommt voran, kam voran, ist vorangekommen',
@@ -6927,6 +8129,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `396-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'erlöschen, erlischt, erlosch, ist erloschen',
@@ -6938,6 +8142,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `178-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'austauschen, tauscht aus, tauschte aus, hat ausgetauscht',
@@ -6949,6 +8155,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `500-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'niedergeschlagen',
@@ -6960,6 +8168,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `205-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'ein',
         pluralEnding: '',
         wordDe: 'herkömmliches Verfahren',
@@ -6972,6 +8182,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `19-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'das',
         pluralEnding: '',
         wordDe: 'Auftreten',
@@ -6983,6 +8195,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `411-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'sensibel',
@@ -6994,6 +8208,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `273-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'mithilfe + G',
@@ -7006,6 +8222,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `130-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -n',
         wordDe: 'Plombe',
@@ -7017,6 +8235,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `496-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'auffallen, fällt auf, fiel auf, ist aufgefallen',
@@ -7028,6 +8248,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `106-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'überschaubar',
@@ -7039,6 +8261,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `408-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'maßgebend',
@@ -7050,6 +8274,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `61-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'unterordnen, ordnet unter, ordnete unter, hat untergeordnet',
@@ -7061,6 +8287,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `68-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -n',
         wordDe: 'Bandansage',
@@ -7073,6 +8301,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `227-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'verderben, verdirbt, verdarb, hat verdorben',
@@ -7084,6 +8314,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `290-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'aufzeigen, zeigt auf, zeigte auf, hat aufgezeigt',
@@ -7095,6 +8327,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `212-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: '',
         wordDe: 'Stammkundschaft',
@@ -7108,6 +8342,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `446-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'tragfähig',
@@ -7119,6 +8355,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `654-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ' , -en',
         wordDe: 'Signatur',
@@ -7130,6 +8368,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `52-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'auflisten, listet auf, listete auf, hat aufgelistet',
@@ -7141,6 +8381,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `272-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'Mehrweg-',
@@ -7152,6 +8394,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `81-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -n',
         wordDe: 'Verständnisfrage',
@@ -7165,6 +8409,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `56-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'vorsehen, sieht vor, sah vor, hat vorgesehen',
@@ -7176,6 +8422,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `304-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'umfassen, umfasst, umfasste, hat umfasst',
@@ -7187,6 +8435,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `260-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'das',
         pluralEnding: '',
         wordDe: 'Probe-Abo',
@@ -7198,6 +8448,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `640-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'das',
         pluralEnding: ', -e',
         wordDe: 'Kunstwerk',
@@ -7209,6 +8461,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `219-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -en',
         wordDe: 'Neuerung',
@@ -7221,6 +8475,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `495-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -n',
         wordDe: 'Versichertenkarte',
@@ -7232,6 +8488,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `604-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'das',
         pluralEnding: ', "er',
         wordDe: 'Bruttogehalt',
@@ -7243,6 +8501,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `577-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'am längeren Hebel sitzen, sitzt, saß, hat gesessen',
@@ -7254,6 +8514,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `421-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'adäquat',
@@ -7265,6 +8527,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `168-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -en',
         wordDe: 'Dienstleistung',
@@ -7276,6 +8540,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `172-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'aufstocken, stockt auf, stockte auf, hat aufgestockt',
@@ -7287,6 +8553,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `327-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'handelsüblich',
@@ -7298,6 +8566,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `64-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'der',
         pluralEnding: '',
         wordDe: 'Flurfunk',
@@ -7310,6 +8580,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `372-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -en',
         wordDe: 'Weltanschauung',
@@ -7322,6 +8594,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `85-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'schaffen, schafft, schuf, hat geschaffen',
@@ -7334,6 +8608,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `361-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'sich absetzen von, setzt sich ab, setzte sich ab, hat sich abgesetzt',
@@ -7345,6 +8621,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `100-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'der',
         pluralEnding: '',
         wordDe: 'Förderbedarf',
@@ -7358,6 +8636,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `256-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'deutschlandweit',
@@ -7369,6 +8649,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `72-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'der',
         pluralEnding: ', -äge',
         wordDe: 'Eintrag',
@@ -7380,6 +8662,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `34-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'der',
         pluralEnding: ', -räume',
         wordDe: 'Umkleideraum',
@@ -7391,6 +8675,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `364-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'ein Produkt vertreiben, vertreibt, vertrieb, hat vertrieben',
@@ -7402,6 +8688,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `429-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'der',
         pluralEnding: '',
         wordDe: 'Blick hinter die Kulissen',
@@ -7415,6 +8703,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `679-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'das',
         pluralEnding: '',
         wordDe: 'Zusammenspiel von',
@@ -7427,6 +8717,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `220-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -en',
         wordDe: 'Sortimentsanpassung',
@@ -7440,6 +8732,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `54-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'durchfallen, fällt durch, durchfiel, ist durchgefallen',
@@ -7451,6 +8745,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `351-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'kalkulieren, kalkuliert, kalkulierte, hat kalkuliert',
@@ -7462,6 +8758,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `345-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -en',
         wordDe: 'Existenzgründung',
@@ -7475,6 +8773,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `292-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'der',
         pluralEnding: '',
         wordDe: 'Datenschutz',
@@ -7488,6 +8788,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `426-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'der',
         pluralEnding: ', -üsse',
         wordDe: 'Schnappschuss',
@@ -7499,6 +8801,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `210-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'ausführlich',
@@ -7510,6 +8814,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `398-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -en',
         wordDe: 'Erwerbstätigkeit',
@@ -7521,6 +8827,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `147-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'den eigenen Standpunkt darlegen, legt dar, legte dar, hat dargelegt',
@@ -7532,6 +8840,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `303-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -en',
         wordDe: 'Herausforderung',
@@ -7544,6 +8854,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `624-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'bereithalten, hält bereit, hielt bereit, hat bereitgehalten',
@@ -7555,6 +8867,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `258-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -en',
         wordDe: 'Fehlermeldung',
@@ -7566,6 +8880,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `170-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'erfreulicherweise',
@@ -7578,6 +8894,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `343-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'erfahrungsgemäß',
@@ -7589,6 +8907,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `23-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -en',
         wordDe: 'Subventionierung',
@@ -7600,6 +8920,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `132-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'das',
         pluralEnding: ', -e',
         wordDe: 'Löschgerät',
@@ -7611,6 +8933,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `184-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: '',
         wordDe: 'Entspannung',
@@ -7623,6 +8947,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `473-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'das',
         pluralEnding: ', -se',
         wordDe: 'Hindernis',
@@ -7634,6 +8960,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `556-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'durchschnittlich',
@@ -7645,6 +8973,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `152-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'gründen, gründet, gründete, hat gegründet',
@@ -7657,6 +8987,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `518-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'zielführend',
@@ -7668,6 +9000,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `313-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: '',
         wordDe: 'Skills',
@@ -7679,6 +9013,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `348-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'der',
         pluralEnding: ', -pläne',
         wordDe: 'Businessplan',
@@ -7692,6 +9028,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `242-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'einräumen, räumt ein, räumte ein, hat eingeräumt',
@@ -7703,6 +9041,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `90-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'der',
         pluralEnding: ', -e',
         wordDe: 'Belang',
@@ -7714,6 +9054,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `460-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'schwören auf, schwört, schwor, hat geschworen',
@@ -7726,6 +9068,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `656-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'zeitnah',
@@ -7737,6 +9081,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `420-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'daherkommen, kommt daher, kam daher, ist dahergekommen',
@@ -7748,6 +9094,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `57-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'der',
         pluralEnding: ', -e',
         wordDe: 'Zugriff',
@@ -7759,6 +9107,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `514-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'der',
         pluralEnding: ', -e',
         wordDe: 'Umstand',
@@ -7770,6 +9120,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `16-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'sich einen Eindruck verschaffen, verschafft, verschaffte, hat verschafft',
@@ -7781,6 +9133,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `6-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'die',
         pluralEnding: ', -en',
         wordDe: 'Meisterprüfung',
@@ -7793,6 +9147,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `264-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: '',
         pluralEnding: '',
         wordDe: 'abstürzen, stürzt ab, stürzte ab, ist abgestürzt',
@@ -7804,6 +9160,8 @@ export const C1_data: ILanguageCard[] = [
     },
     {
         id: `209-${WORD_LEVELS.C1}`,
+        sourceBook: 'Aspekte Beruf C1',
+        level: WORD_LEVELS.C1,
         article: 'das',
         pluralEnding: ', -e',
         wordDe: 'Alleinstellungsmerkmal',

--- a/src/interfaces/interfaces.ts
+++ b/src/interfaces/interfaces.ts
@@ -1,4 +1,4 @@
-import { WORD_CLASSES } from '@/enums/enums'
+import { WORD_CLASSES, WORD_LEVELS } from '@/enums/enums'
 
 export interface ILanguageCard {
     id: string
@@ -10,6 +10,9 @@ export interface ILanguageCard {
     exampleDe: string
     exampleRu: string
     fileKeyUploadthing: string
+    sourceBook?: string
+    level?: (typeof WORD_LEVELS)[keyof typeof WORD_LEVELS]
+    addedAt?: string
     multiple?: ILanguageCard[]
 }
 export interface IWordCardProperties {

--- a/src/lib/card-schema.ts
+++ b/src/lib/card-schema.ts
@@ -1,0 +1,40 @@
+import { z } from 'zod'
+import { WORD_CLASSES, WORD_LEVELS } from '@/enums/enums'
+
+const NOUN_CLASSES: string[] = [
+    WORD_CLASSES.MASKULIN,
+    WORD_CLASSES.FEMININ,
+    WORD_CLASSES.NEUTRAL,
+    WORD_CLASSES.PLURAL,
+]
+
+function articleMatchesClass(article: string, wordClass: string): boolean {
+    if (!NOUN_CLASSES.includes(wordClass)) return true
+    if (article === 'der') return wordClass === WORD_CLASSES.MASKULIN
+    if (article === 'das') return wordClass === WORD_CLASSES.NEUTRAL
+    if (article === 'die')
+        return wordClass === WORD_CLASSES.FEMININ || wordClass === WORD_CLASSES.PLURAL
+    return true
+}
+
+export const cardSchema = z
+    .object({
+        id: z.string().min(1),
+        article: z.string(),
+        pluralEnding: z.string(),
+        wordDe: z.string().min(1),
+        wordRu: z.string().min(1),
+        wordClass: z.nativeEnum(WORD_CLASSES),
+        exampleDe: z.string().min(1),
+        exampleRu: z.string().min(1),
+        fileKeyUploadthing: z.string().min(1),
+        sourceBook: z.string().optional(),
+        level: z.nativeEnum(WORD_LEVELS).optional(),
+        addedAt: z.string().optional(),
+    })
+    .refine(card => articleMatchesClass(card.article, card.wordClass), {
+        message: 'article does not match wordClass gender',
+        path: ['wordClass'],
+    })
+
+export type CardSchema = z.infer<typeof cardSchema>


### PR DESCRIPTION
## Summary

Adds optional provenance fields (`sourceBook`, `level`, `addedAt`) to the flashcard model and populates them across all 739 cards (C1 → "Aspekte Beruf C1", A2-B2 → "various"), preparing the dataset for multi-source vocabulary expansion. Introduces a zod card schema as the card contract, including an article↔wordClass gender check (noun classes only); the check flagged two C1 cards, corrected here. Existing card IDs are kept (already stable post-shuffle), so persisted favorites are unaffected.

## Changes

- `interfaces.ts`: `ILanguageCard` gains optional `sourceBook` / `level` / `addedAt`.
- `lib/card-schema.ts`: new zod `cardSchema` with an `article`↔`wordClass` refinement (der→Maskulin, das→Neutral, die→Feminin/Plural; non-noun classes exempt).
- `data/C1-data.ts` and `data/A2-B2-data.ts`: `sourceBook` + `level` added to every card.
- `data/C1-data.ts`: corrected `Lieferengpass` (`article` die→der) and `Förderung` (`wordClass` Neutral→Feminin).

## Test Plan

- [x] Offline data validator (regex mirror of the schema): 739 cards, 739 unique ids, 0 missing provenance, 0 article↔wordClass mismatch.
- [x] zod API runtime-verified (`nativeEnum` / `refine`).
- [ ] `tsc --noEmit` / `vitest` — deferred to the Vercel build / CI (no local registry access).
- [ ] Manual: cards render unchanged (provenance is non-visual); favorites persist (ids unchanged).