### PR TITLE
perf: Faster card image loading (next/image, lazy, placeholder)

### DIFF
--- a/src/components/ImageWithLoading.tsx
+++ b/src/components/ImageWithLoading.tsx
@@ -1,45 +1,35 @@
 'use client'
 
-import React, { useEffect, useState } from 'react'
+import React, { useState } from 'react'
 import Image from 'next/image'
+import { cn } from '@/lib/utils'
 import { IImageWithLoadingProperties } from '@/interfaces/interfaces'
-import { Loader } from './Loader'
 import { Ban } from 'lucide-react'
 
-const ImageWithLoading = ({ src, alt }: IImageWithLoadingProperties) => {
-    const [loading, setLoading] = useState(true)
+const ImageWithLoading = ({ src, alt, priority = false }: IImageWithLoadingProperties) => {
+    const [loaded, setLoaded] = useState(false)
     const [error, setError] = useState(false)
-
-    useEffect(() => {
-        let active = true
-        const fetchImage = async () => {
-            try {
-                const response = await fetch(src)
-                if (!response.ok) throw new Error('Image load failed')
-                if (active) setError(false)
-            } catch {
-                if (active) setError(true)
-            } finally {
-                if (active) setLoading(false)
-            }
-        }
-        fetchImage()
-        return () => {
-            active = false
-        }
-    }, [src])
-
-    if (loading && !error) {
-        return <Loader />
-    }
 
     if (error) {
         return <Ban />
     }
 
     return (
-        <div className="relative aspect-[9/16]">
-            <Image src={src} alt={alt} fill sizes="320px" className="rounded-t-xl" />
+        <div className="relative aspect-[9/16] bg-muted">
+            <Image
+                src={src}
+                alt={alt}
+                fill
+                sizes="320px"
+                priority={priority}
+                unoptimized={process.env.NODE_ENV !== 'production'}
+                className={cn(
+                    'rounded-t-xl transition-opacity duration-300',
+                    loaded ? 'opacity-100' : 'opacity-0'
+                )}
+                onLoad={() => setLoaded(true)}
+                onError={() => setError(true)}
+            />
         </div>
     )
 }

--- a/src/components/WordCard.tsx
+++ b/src/components/WordCard.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React, { useState, useEffect } from 'react'
+import React, { useState } from 'react'
 import { motion } from 'framer-motion'
 import { Card, CardContent } from './ui/card'
 import { IWordCardProperties } from '@/interfaces/interfaces'
@@ -18,9 +18,8 @@ const animationTransitionConfig = {
     type: 'tween',
 }
 
-export const WordCard = ({ data }: IWordCardProperties) => {
+export const WordCard = ({ data, priority = false }: IWordCardProperties) => {
     const [isFlipped, setIsFlipped] = useState(false)
-    const [imageUrl, setImageUrl] = useState<string | null>(null)
 
     const isFavorite = useCardsStore(state => state.favoriteCards.some(card => card.id === data.id))
 
@@ -50,23 +49,6 @@ export const WordCard = ({ data }: IWordCardProperties) => {
         }
     }
 
-    useEffect(() => {
-        const fetchImage = async () => {
-            try {
-                const response = await fetch(`${URL_IMAGES}${fileKeyUploadthing}`)
-                if (response.ok) {
-                    const blob = await response.blob()
-                    setImageUrl(URL.createObjectURL(blob))
-                } else {
-                    console.error('Failed to fetch image')
-                }
-            } catch (error) {
-                console.error('Error fetching image:', error)
-            }
-        }
-
-        fetchImage()
-    }, [fileKeyUploadthing])
     const regex = /^\d{1,}-/
     const result = id.replace(regex, '')
     return (
@@ -100,7 +82,11 @@ export const WordCard = ({ data }: IWordCardProperties) => {
                         })}
                     />
                 </div>
-                {imageUrl && <ImageWithLoading src={imageUrl} alt={wordDe} />}
+                <ImageWithLoading
+                    src={`${URL_IMAGES}${fileKeyUploadthing}`}
+                    alt={wordDe}
+                    priority={priority}
+                />
                 <CardContent
                     className={cn(
                         'w-full p-1',

--- a/src/components/WordCarousel.tsx
+++ b/src/components/WordCarousel.tsx
@@ -1,33 +1,14 @@
 'use client'
 
-import React, { useEffect, useState } from 'react'
+import React from 'react'
 import { ILanguageCard } from '@/interfaces/interfaces'
 import { MaxWidthWrapper, WordCard } from '.'
-import { Carousel, CarouselContent, CarouselItem, type CarouselApi } from './ui/carousel'
+import { Carousel, CarouselContent, CarouselItem } from './ui/carousel'
 
 export function WordCarousel({ data }: { data: ILanguageCard[] }) {
-    const [api, setApi] = useState<CarouselApi>()
-
-    useEffect(() => {
-        if (!api) {
-            console.log('[wk-debug-embla] api not ready')
-            return
-        }
-        console.log(
-            `[wk-debug-embla] ${JSON.stringify({
-                cards: data.length,
-                slides: api.slideNodes().length,
-                snaps: api.scrollSnapList().length,
-                canNext: api.canScrollNext(),
-                canPrev: api.canScrollPrev(),
-            })}`
-        )
-    }, [api, data])
-
     return (
         <MaxWidthWrapper className="flex">
             <Carousel
-                setApi={setApi}
                 opts={{
                     align: 'start',
                 }}
@@ -35,9 +16,9 @@ export function WordCarousel({ data }: { data: ILanguageCard[] }) {
                 className="w-full"
             >
                 <CarouselContent className="-mt-1 items-center h-[616px] ">
-                    {data.map(card => (
+                    {data.map((card, index) => (
                         <CarouselItem key={card.id} className="pt-1 rounded-b-xl">
-                            <WordCard data={card} />
+                            <WordCard data={card} priority={index === 0} />
                         </CarouselItem>
                     ))}
                 </CarouselContent>

--- a/src/interfaces/interfaces.ts
+++ b/src/interfaces/interfaces.ts
@@ -17,10 +17,12 @@ export interface ILanguageCard {
 }
 export interface IWordCardProperties {
     data: ILanguageCard
+    priority?: boolean
 }
 export interface IImageWithLoadingProperties {
     src: string
     alt: string
+    priority?: boolean
 }
 
 export interface ICardsStore {


### PR DESCRIPTION
## Summary

Replaces the per-card blob-fetch image pipeline with `next/image`. Previously each card fetched its image as a blob in a client effect and passed a `blob:` URL to `next/image` — the optimizer was bypassed (full-size originals), the image was fetched twice, the object URL leaked, and every card on the page loaded eagerly. Now the image is rendered directly by `next/image` with native lazy-loading, a `priority` hint on the first carousel card, a `bg-muted` placeholder + fade-in (no spinner/blank gap), and `unoptimized` only in development. In production the Next image optimizer resizes the utfs.io originals to small AVIF/WebP. Dev keeps `unoptimized` because the local dev server cannot reach utfs.io for server-side optimization, while the browser can.

## Changes

- `ImageWithLoading.tsx`: renders `next/image` directly (removed the redundant `fetch(src)` effect); `bg-muted` placeholder + opacity fade-in via `onLoad`; `Ban` on `onError`; `unoptimized={process.env.NODE_ENV !== 'production'}`.
- `WordCard.tsx`: removed the blob-fetch effect, `imageUrl` state, and `URL.createObjectURL`; passes the direct `${URL_IMAGES}${fileKeyUploadthing}` URL plus a `priority` prop.
- `WordCarousel.tsx`: passes `priority` to the first card; removed a dead debug-logging effect and its unused embla `api` state.
- `interfaces.ts`: `IWordCardProperties` and `IImageWithLoadingProperties` gain an optional `priority`.

## Test Plan

- [x] Dev (`next dev`): `/page/1` → 200; HTML emits direct utfs.io `<img src>` (dev `unoptimized`); `bg-muted` placeholder + fade classes present; compiles clean; images display and load lazily.
- [ ] **Vercel preview (required before merge):** confirm production-optimized images load (the optimizer reaches utfs.io on Vercel) AND are materially smaller (AVIF). Local dev cannot exercise the prod path.
- [ ] `tsc --noEmit` / `vitest` — deferred to the Vercel build (local module resolution unreliable).