### PR TITLE
fix: Prevent footer/pagination overlap on short viewports

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2,9 +2,12 @@
 @tailwind components;
 @tailwind utilities;
 
-html,
-body {
+html {
     height: 100%;
+}
+
+body {
+    min-height: 100%;
 }
 
 .wrapper {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -33,7 +33,7 @@ export default function RootLayout({
                 className={`${geistSans.variable} ${geistMono.variable} antialiased`}
                 // style={{ fontFamily: 'DynaPuffRegular, sans-serif' }}
             >
-                <div className="flex flex-col h-full">
+                <div className="flex flex-col min-h-screen">
                     <ThemeProvider
                         attribute="class"
                         defaultTheme="system"

--- a/src/app/page/[page]/page.tsx
+++ b/src/app/page/[page]/page.tsx
@@ -29,7 +29,7 @@ export default function PaginatedPage({ params, searchParams }: PaginatedPagePro
     const { slice, totalPages, page } = paginate(cards, requestedPage, size)
 
     return (
-        <div className="h-full flex flex-col justify-between items-center flex-grow">
+        <div className="flex flex-col justify-between items-center flex-grow">
             <section className="flex flex-col items-center justify-center gap-2 px-4 py-2">
                 {query && (
                     <p className="text-center text-sm py-1">


### PR DESCRIPTION
## Summary

On desktop viewports shorter than the page content (header + the fixed-height card carousel + pagination + footer), the layout was locked to the viewport height (`html,body{height:100%}` plus a root `h-full` flex column), so the content overflowed and the footer overlapped the pagination instead of the page scrolling. This makes the page shell grow with its content and scroll when needed, so the footer always sits below the pagination; on short pages the footer still sticks to the bottom.

## Changes

- `globals.css`: `body` now uses `min-height: 100%` (was `height: 100%`) so it grows with content; `html` keeps `height: 100%`.
- `layout.tsx`: root flex column `h-full` → `min-h-screen`.
- `page/[page]/page.tsx`: removed `h-full` from the page wrapper so the fixed-height carousel can't cap the column height.

## Test Plan

- [x] Compiles; `/` and `/page/1` → 200 (dev).
- [ ] **Vercel preview (visual):** on a desktop viewport shorter than the card the page scrolls and the footer is below the pagination (no overlap); on a tall viewport the footer sticks to the bottom. Local visual verification was not possible in this environment.