### PR TITLE
perf: Prefetch initial cards + theme-aware shimmer placeholder

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -10,6 +10,15 @@ body {
     min-height: 100%;
 }
 
+@keyframes shimmer {
+    0% {
+        background-position: 200% 0;
+    }
+    100% {
+        background-position: -200% 0;
+    }
+}
+
 .wrapper {
     display: flex;
     flex-direction: column;

--- a/src/components/ImageWithLoading.tsx
+++ b/src/components/ImageWithLoading.tsx
@@ -6,7 +6,12 @@ import { cn } from '@/lib/utils'
 import { IImageWithLoadingProperties } from '@/interfaces/interfaces'
 import { Ban } from 'lucide-react'
 
-const ImageWithLoading = ({ src, alt, priority = false }: IImageWithLoadingProperties) => {
+const ImageWithLoading = ({
+    src,
+    alt,
+    priority = false,
+    eager = false,
+}: IImageWithLoadingProperties) => {
     const [loaded, setLoaded] = useState(false)
     const [error, setError] = useState(false)
 
@@ -15,13 +20,20 @@ const ImageWithLoading = ({ src, alt, priority = false }: IImageWithLoadingPrope
     }
 
     return (
-        <div className="relative aspect-[9/16] bg-muted">
+        <div className="relative aspect-[9/16] overflow-hidden rounded-t-xl bg-neutral-200 dark:bg-neutral-900">
+            {!loaded && (
+                <div
+                    aria-hidden
+                    className="pointer-events-none absolute inset-0 bg-[length:200%_100%] motion-safe:animate-[shimmer_1.4s_ease-in-out_infinite] bg-[linear-gradient(105deg,transparent_0%,rgba(255,255,255,0.65)_45%,rgba(255,255,255,0.95)_50%,rgba(255,255,255,0.65)_55%,transparent_100%)] dark:bg-[linear-gradient(105deg,transparent_0%,rgba(255,255,255,0.06)_45%,rgba(255,255,255,0.10)_50%,rgba(255,255,255,0.06)_55%,transparent_100%)]"
+                />
+            )}
             <Image
                 src={src}
                 alt={alt}
                 fill
                 sizes="320px"
                 priority={priority}
+                loading={priority ? undefined : eager ? 'eager' : 'lazy'}
                 unoptimized={process.env.NODE_ENV !== 'production'}
                 className={cn(
                     'rounded-t-xl transition-opacity duration-300',

--- a/src/components/WordCard.tsx
+++ b/src/components/WordCard.tsx
@@ -18,7 +18,7 @@ const animationTransitionConfig = {
     type: 'tween',
 }
 
-export const WordCard = ({ data, priority = false }: IWordCardProperties) => {
+export const WordCard = ({ data, priority = false, eager = false }: IWordCardProperties) => {
     const [isFlipped, setIsFlipped] = useState(false)
 
     const isFavorite = useCardsStore(state => state.favoriteCards.some(card => card.id === data.id))
@@ -86,6 +86,7 @@ export const WordCard = ({ data, priority = false }: IWordCardProperties) => {
                     src={`${URL_IMAGES}${fileKeyUploadthing}`}
                     alt={wordDe}
                     priority={priority}
+                    eager={eager}
                 />
                 <CardContent
                     className={cn(

--- a/src/components/WordCarousel.tsx
+++ b/src/components/WordCarousel.tsx
@@ -18,7 +18,7 @@ export function WordCarousel({ data }: { data: ILanguageCard[] }) {
                 <CarouselContent className="-mt-1 items-center h-[616px] ">
                     {data.map((card, index) => (
                         <CarouselItem key={card.id} className="pt-1 rounded-b-xl">
-                            <WordCard data={card} priority={index === 0} />
+                            <WordCard data={card} priority={index === 0} eager={index > 0 && index < 3} />
                         </CarouselItem>
                     ))}
                 </CarouselContent>

--- a/src/interfaces/interfaces.ts
+++ b/src/interfaces/interfaces.ts
@@ -18,11 +18,13 @@ export interface ILanguageCard {
 export interface IWordCardProperties {
     data: ILanguageCard
     priority?: boolean
+    eager?: boolean
 }
 export interface IImageWithLoadingProperties {
     src: string
     alt: string
     priority?: boolean
+    eager?: boolean
 }
 
 export interface ICardsStore {


### PR DESCRIPTION
## Summary

Two image-loading polish changes. (1) **Prefetch:** the first carousel card keeps `priority` and the next two load eagerly (`loading="eager"`), so scrolling through the top cards is instant; deeper cards stay lazy. (2) **Placeholder:** replaces the flat `bg-muted` block (which read as a gray box) with a theme-aware animated shimmer — a dark `neutral-900` panel + subtle sheen in dark mode, a light `neutral-200` panel + white sweep in light mode — rendered as a sibling layer that unmounts on load and respects `prefers-reduced-motion`. (Per the placeholder research, a per-image blur-up is a follow-up that needs a network-enabled build step.)

## Changes

- `ImageWithLoading.tsx`: theme-aware shimmer sibling (`bg-neutral-200 dark:bg-neutral-900` panel + `motion-safe:animate-[shimmer]` diagonal sheen with light/dark gradient variants), unmounts on `onLoad`; `loading` driven by a new optional `eager` prop.
- `WordCarousel.tsx`: passes `priority` to card 0 and `eager` to cards 1–2.
- `WordCard.tsx` / `interfaces.ts`: optional `eager` prop plumbed through.
- `globals.css`: `@keyframes shimmer`.

## Test Plan

- [x] Dev: `/page/1` → 200, compiles; shimmer markup + light/dark variants + eager/lazy distribution present.
- [ ] Visual (prod): shimmer animates in both themes (toggle), gray box gone, top-card scroll instant. Local visual verification not possible in this environment.